### PR TITLE
cluster: support LockWithContext

### DIFF
--- a/cluster/job.go
+++ b/cluster/job.go
@@ -18,7 +18,6 @@ const (
 // JobPluginAPI is the plugin API interface required to schedule jobs.
 type JobPluginAPI interface {
 	MutexPluginAPI
-	KVSet(key string, value []byte) *model.AppError
 }
 
 // JobConfig defines the configuration of a scheduled job.
@@ -102,8 +101,8 @@ func (j *Job) saveMetadata(metadata jobMetadata) error {
 		return errors.Wrap(err, "failed to marshal data")
 	}
 
-	appErr := j.pluginAPI.KVSet(j.key, data)
-	if appErr != nil {
+	ok, appErr := j.pluginAPI.KVSetWithOptions(j.key, data, model.PluginKVSetOptions{})
+	if appErr != nil || !ok {
 		return errors.Wrap(appErr, "failed to set data")
 	}
 

--- a/cluster/job.go
+++ b/cluster/job.go
@@ -58,10 +58,15 @@ func Schedule(pluginAPI JobPluginAPI, key string, config JobConfig, callback fun
 
 	key = cronPrefix + key
 
+	mutex, err := NewMutex(pluginAPI, key)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create job mutex")
+	}
+
 	job := &Job{
 		pluginAPI: pluginAPI,
 		key:       key,
-		mutex:     NewMutex(pluginAPI, key),
+		mutex:     mutex,
 		config:    config,
 		callback:  callback,
 		stop:      make(chan bool),

--- a/cluster/job.go
+++ b/cluster/job.go
@@ -18,7 +18,6 @@ const (
 // JobPluginAPI is the plugin API interface required to schedule jobs.
 type JobPluginAPI interface {
 	MutexPluginAPI
-	KVGet(key string) ([]byte, *model.AppError)
 }
 
 // JobConfig defines the configuration of a scheduled job.

--- a/cluster/job.go
+++ b/cluster/job.go
@@ -18,6 +18,7 @@ const (
 // JobPluginAPI is the plugin API interface required to schedule jobs.
 type JobPluginAPI interface {
 	MutexPluginAPI
+	KVGet(key string) ([]byte, *model.AppError)
 }
 
 // JobConfig defines the configuration of a scheduled job.

--- a/cluster/job.go
+++ b/cluster/job.go
@@ -18,6 +18,7 @@ const (
 // JobPluginAPI is the plugin API interface required to schedule jobs.
 type JobPluginAPI interface {
 	MutexPluginAPI
+	KVSet(key string, value []byte) *model.AppError
 }
 
 // JobConfig defines the configuration of a scheduled job.
@@ -101,8 +102,8 @@ func (j *Job) saveMetadata(metadata jobMetadata) error {
 		return errors.Wrap(err, "failed to marshal data")
 	}
 
-	ok, appErr := j.pluginAPI.KVSetWithOptions(j.key, data, model.PluginKVSetOptions{})
-	if appErr != nil || !ok {
+	appErr := j.pluginAPI.KVSet(j.key, data)
+	if appErr != nil {
 		return errors.Wrap(appErr, "failed to set data")
 	}
 

--- a/cluster/job_example_test.go
+++ b/cluster/job_example_test.go
@@ -1,10 +1,14 @@
 package cluster
 
-import "time"
+import (
+	"time"
+
+	"github.com/mattermost/mattermost-server/v5/plugin"
+)
 
 func ExampleSchedule() {
 	// Use p.API from your plugin instead.
-	pluginAPI := NewMockMutexPluginAPI(nil)
+	pluginAPI := plugin.API(nil)
 
 	callback := func() {
 		// periodic work to do

--- a/cluster/job_test.go
+++ b/cluster/job_test.go
@@ -6,20 +6,31 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSchedule(t *testing.T) {
+	t.Parallel()
+
+	makeKey := func() string {
+		return model.NewId()
+	}
+
 	t.Run("invalid interval", func(t *testing.T) {
+		t.Parallel()
+
 		mockPluginAPI := newMockPluginAPI(t)
 
-		job, err := Schedule(mockPluginAPI, "key", JobConfig{}, func() {})
+		job, err := Schedule(mockPluginAPI, makeKey(), JobConfig{}, func() {})
 		require.Error(t, err, "must specify non-zero job config interval")
 		require.Nil(t, job)
 	})
 
 	t.Run("single-threaded", func(t *testing.T) {
+		t.Parallel()
+
 		mockPluginAPI := newMockPluginAPI(t)
 
 		count := new(int32)
@@ -27,7 +38,7 @@ func TestSchedule(t *testing.T) {
 			atomic.AddInt32(count, 1)
 		}
 
-		job, err := Schedule(mockPluginAPI, "key", JobConfig{Interval: 100 * time.Millisecond}, callback)
+		job, err := Schedule(mockPluginAPI, makeKey(), JobConfig{Interval: 100 * time.Millisecond}, callback)
 		require.NoError(t, err)
 		require.NotNil(t, job)
 
@@ -46,6 +57,8 @@ func TestSchedule(t *testing.T) {
 	})
 
 	t.Run("multi-threaded, single job", func(t *testing.T) {
+		t.Parallel()
+
 		mockPluginAPI := newMockPluginAPI(t)
 
 		count := new(int32)
@@ -55,8 +68,10 @@ func TestSchedule(t *testing.T) {
 
 		var jobs []*Job
 
+		key := makeKey()
+
 		for i := 0; i < 3; i++ {
-			job, err := Schedule(mockPluginAPI, "key", JobConfig{Interval: 100 * time.Millisecond}, callback)
+			job, err := Schedule(mockPluginAPI, key, JobConfig{Interval: 100 * time.Millisecond}, callback)
 			require.NoError(t, err)
 			require.NotNil(t, job)
 
@@ -87,6 +102,8 @@ func TestSchedule(t *testing.T) {
 	})
 
 	t.Run("multi-threaded, multiple jobs", func(t *testing.T) {
+		t.Parallel()
+
 		mockPluginAPI := newMockPluginAPI(t)
 
 		countA := new(int32)
@@ -99,15 +116,18 @@ func TestSchedule(t *testing.T) {
 			atomic.AddInt32(countB, 1)
 		}
 
+		keyA := makeKey()
+		keyB := makeKey()
+
 		var jobs []*Job
 		for i := 0; i < 3; i++ {
 			var key string
 			var callback func()
 			if i <= 1 {
-				key = "keyA"
+				key = keyA
 				callback = callbackA
 			} else {
-				key = "keyB"
+				key = keyB
 				callback = callbackB
 			}
 

--- a/cluster/job_test.go
+++ b/cluster/job_test.go
@@ -10,19 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type MockJobPluginAPI struct {
-	*MockMutexPluginAPI
-}
-
-func NewMockJobPluginAPI(t *testing.T) *MockJobPluginAPI {
-	return &MockJobPluginAPI{
-		MockMutexPluginAPI: NewMockMutexPluginAPI(t),
-	}
-}
-
 func TestSchedule(t *testing.T) {
 	t.Run("invalid interval", func(t *testing.T) {
-		mockPluginAPI := NewMockJobPluginAPI(t)
+		mockPluginAPI := newMockPluginAPI(t)
 
 		job, err := Schedule(mockPluginAPI, "key", JobConfig{}, func() {})
 		require.Error(t, err, "must specify non-zero job config interval")
@@ -30,7 +20,7 @@ func TestSchedule(t *testing.T) {
 	})
 
 	t.Run("single-threaded", func(t *testing.T) {
-		mockPluginAPI := NewMockJobPluginAPI(t)
+		mockPluginAPI := newMockPluginAPI(t)
 
 		count := new(int32)
 		callback := func() {
@@ -56,7 +46,7 @@ func TestSchedule(t *testing.T) {
 	})
 
 	t.Run("multi-threaded, single job", func(t *testing.T) {
-		mockPluginAPI := NewMockJobPluginAPI(t)
+		mockPluginAPI := newMockPluginAPI(t)
 
 		count := new(int32)
 		callback := func() {
@@ -97,7 +87,7 @@ func TestSchedule(t *testing.T) {
 	})
 
 	t.Run("multi-threaded, multiple jobs", func(t *testing.T) {
-		mockPluginAPI := NewMockJobPluginAPI(t)
+		mockPluginAPI := newMockPluginAPI(t)
 
 		countA := new(int32)
 		callbackA := func() {

--- a/cluster/mock_plugin_api_test.go
+++ b/cluster/mock_plugin_api_test.go
@@ -30,6 +30,15 @@ func (pluginAPI *mockPluginAPI) setFailing(failing bool) {
 	pluginAPI.failing = failing
 }
 
+func (pluginAPI *mockPluginAPI) clear() {
+	pluginAPI.lock.Lock()
+	defer pluginAPI.lock.Unlock()
+
+	for k := range pluginAPI.keyValues {
+		delete(pluginAPI.keyValues, k)
+	}
+}
+
 func (pluginAPI *mockPluginAPI) KVGet(key string) ([]byte, *model.AppError) {
 	pluginAPI.lock.Lock()
 	defer pluginAPI.lock.Unlock()
@@ -41,33 +50,7 @@ func (pluginAPI *mockPluginAPI) KVGet(key string) ([]byte, *model.AppError) {
 	return pluginAPI.keyValues[key], nil
 }
 
-func (pluginAPI *mockPluginAPI) KVSet(key string, value []byte) *model.AppError {
-	pluginAPI.lock.Lock()
-	defer pluginAPI.lock.Unlock()
-
-	if pluginAPI.failing {
-		return &model.AppError{Message: "fake error"}
-	}
-
-	pluginAPI.keyValues[key] = value
-
-	return nil
-}
-
-func (pluginAPI *mockPluginAPI) KVDelete(key string) *model.AppError {
-	pluginAPI.lock.Lock()
-	defer pluginAPI.lock.Unlock()
-
-	if pluginAPI.failing {
-		return &model.AppError{Message: "fake error"}
-	}
-
-	delete(pluginAPI.keyValues, key)
-
-	return nil
-}
-
-func (pluginAPI *mockPluginAPI) KVCompareAndSet(key string, oldValue []byte, value []byte) (bool, *model.AppError) {
+func (pluginAPI *mockPluginAPI) KVSetWithOptions(key string, value []byte, options model.PluginKVSetOptions) (bool, *model.AppError) {
 	pluginAPI.lock.Lock()
 	defer pluginAPI.lock.Unlock()
 
@@ -75,28 +58,17 @@ func (pluginAPI *mockPluginAPI) KVCompareAndSet(key string, oldValue []byte, val
 		return false, &model.AppError{Message: "fake error"}
 	}
 
-	if actualValue := pluginAPI.keyValues[key]; !bytes.Equal(actualValue, oldValue) {
-		return false, nil
+	if options.Atomic {
+		if actualValue := pluginAPI.keyValues[key]; !bytes.Equal(actualValue, options.OldValue) {
+			return false, nil
+		}
 	}
 
-	pluginAPI.keyValues[key] = value
-
-	return true, nil
-}
-
-func (pluginAPI *mockPluginAPI) KVCompareAndDelete(key string, oldValue []byte) (bool, *model.AppError) {
-	pluginAPI.lock.Lock()
-	defer pluginAPI.lock.Unlock()
-
-	if pluginAPI.failing {
-		return false, &model.AppError{Message: "fake error"}
+	if value == nil {
+		delete(pluginAPI.keyValues, key)
+	} else {
+		pluginAPI.keyValues[key] = value
 	}
-
-	if actualValue := pluginAPI.keyValues[key]; !bytes.Equal(actualValue, oldValue) {
-		return false, nil
-	}
-
-	delete(pluginAPI.keyValues, key)
 
 	return true, nil
 }

--- a/cluster/mock_plugin_api_test.go
+++ b/cluster/mock_plugin_api_test.go
@@ -30,15 +30,6 @@ func (pluginAPI *mockPluginAPI) setFailing(failing bool) {
 	pluginAPI.failing = failing
 }
 
-func (pluginAPI *mockPluginAPI) clear() {
-	pluginAPI.lock.Lock()
-	defer pluginAPI.lock.Unlock()
-
-	for k := range pluginAPI.keyValues {
-		delete(pluginAPI.keyValues, k)
-	}
-}
-
 func (pluginAPI *mockPluginAPI) KVGet(key string) ([]byte, *model.AppError) {
 	pluginAPI.lock.Lock()
 	defer pluginAPI.lock.Unlock()
@@ -50,7 +41,33 @@ func (pluginAPI *mockPluginAPI) KVGet(key string) ([]byte, *model.AppError) {
 	return pluginAPI.keyValues[key], nil
 }
 
-func (pluginAPI *mockPluginAPI) KVSetWithOptions(key string, value []byte, options model.PluginKVSetOptions) (bool, *model.AppError) {
+func (pluginAPI *mockPluginAPI) KVSet(key string, value []byte) *model.AppError {
+	pluginAPI.lock.Lock()
+	defer pluginAPI.lock.Unlock()
+
+	if pluginAPI.failing {
+		return &model.AppError{Message: "fake error"}
+	}
+
+	pluginAPI.keyValues[key] = value
+
+	return nil
+}
+
+func (pluginAPI *mockPluginAPI) KVDelete(key string) *model.AppError {
+	pluginAPI.lock.Lock()
+	defer pluginAPI.lock.Unlock()
+
+	if pluginAPI.failing {
+		return &model.AppError{Message: "fake error"}
+	}
+
+	delete(pluginAPI.keyValues, key)
+
+	return nil
+}
+
+func (pluginAPI *mockPluginAPI) KVCompareAndSet(key string, oldValue []byte, value []byte) (bool, *model.AppError) {
 	pluginAPI.lock.Lock()
 	defer pluginAPI.lock.Unlock()
 
@@ -58,17 +75,28 @@ func (pluginAPI *mockPluginAPI) KVSetWithOptions(key string, value []byte, optio
 		return false, &model.AppError{Message: "fake error"}
 	}
 
-	if options.Atomic {
-		if actualValue := pluginAPI.keyValues[key]; !bytes.Equal(actualValue, options.OldValue) {
-			return false, nil
-		}
+	if actualValue := pluginAPI.keyValues[key]; !bytes.Equal(actualValue, oldValue) {
+		return false, nil
 	}
 
-	if value == nil {
-		delete(pluginAPI.keyValues, key)
-	} else {
-		pluginAPI.keyValues[key] = value
+	pluginAPI.keyValues[key] = value
+
+	return true, nil
+}
+
+func (pluginAPI *mockPluginAPI) KVCompareAndDelete(key string, oldValue []byte) (bool, *model.AppError) {
+	pluginAPI.lock.Lock()
+	defer pluginAPI.lock.Unlock()
+
+	if pluginAPI.failing {
+		return false, &model.AppError{Message: "fake error"}
 	}
+
+	if actualValue := pluginAPI.keyValues[key]; !bytes.Equal(actualValue, oldValue) {
+		return false, nil
+	}
+
+	delete(pluginAPI.keyValues, key)
 
 	return true, nil
 }

--- a/cluster/mock_plugin_api_test.go
+++ b/cluster/mock_plugin_api_test.go
@@ -1,0 +1,87 @@
+package cluster
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+)
+
+type mockPluginAPI struct {
+	t *testing.T
+
+	lock      sync.Mutex
+	keyValues map[string][]byte
+	failing   bool
+}
+
+func newMockPluginAPI(t *testing.T) *mockPluginAPI {
+	return &mockPluginAPI{
+		t:         t,
+		keyValues: make(map[string][]byte),
+	}
+}
+
+func (pluginAPI *mockPluginAPI) setFailing(failing bool) {
+	pluginAPI.lock.Lock()
+	defer pluginAPI.lock.Unlock()
+
+	pluginAPI.failing = failing
+}
+
+func (pluginAPI *mockPluginAPI) clear() {
+	pluginAPI.lock.Lock()
+	defer pluginAPI.lock.Unlock()
+
+	for k := range pluginAPI.keyValues {
+		delete(pluginAPI.keyValues, k)
+	}
+}
+
+func (pluginAPI *mockPluginAPI) KVGet(key string) ([]byte, *model.AppError) {
+	pluginAPI.lock.Lock()
+	defer pluginAPI.lock.Unlock()
+
+	if pluginAPI.failing {
+		return nil, &model.AppError{Message: "fake error"}
+	}
+
+	return pluginAPI.keyValues[key], nil
+}
+
+func (pluginAPI *mockPluginAPI) KVSetWithOptions(key string, value []byte, options model.PluginKVSetOptions) (bool, *model.AppError) {
+	pluginAPI.lock.Lock()
+	defer pluginAPI.lock.Unlock()
+
+	if pluginAPI.failing {
+		return false, &model.AppError{Message: "fake error"}
+	}
+
+	if options.Atomic {
+		if actualValue := pluginAPI.keyValues[key]; !bytes.Equal(actualValue, options.OldValue) {
+			return false, nil
+		}
+	}
+
+	if value == nil {
+		delete(pluginAPI.keyValues, key)
+	} else {
+		pluginAPI.keyValues[key] = value
+	}
+
+	return true, nil
+}
+
+func (pluginAPI *mockPluginAPI) LogError(msg string, keyValuePairs ...interface{}) {
+	if pluginAPI.t == nil {
+		return
+	}
+
+	pluginAPI.t.Helper()
+
+	params := []interface{}{msg}
+	params = append(params, keyValuePairs...)
+
+	pluginAPI.t.Log(params...)
+}

--- a/cluster/mutex.go
+++ b/cluster/mutex.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"strconv"
 	"sync"
 	"time"
 
@@ -24,6 +25,7 @@ const (
 
 // MutexPluginAPI is the plugin API interface required to manage mutexes.
 type MutexPluginAPI interface {
+	KVGet(key string) ([]byte, *model.AppError)
 	KVSetWithOptions(key string, value []byte, options model.PluginKVSetOptions) (bool, *model.AppError)
 	LogError(msg string, keyValuePairs ...interface{})
 }
@@ -31,7 +33,10 @@ type MutexPluginAPI interface {
 // Mutex is similar to sync.Mutex, except usable by multiple plugin instances across a cluster.
 //
 // Internally, a mutex relies on an atomic key-value set operation as exposed by the Mattermost
-// plugin API.
+// plugin API. Note that it explicitly does not rely on the built-in support for key value expiry,
+// since the implementation for same in the server was partially broken prior to v5.22 and thus
+// unreliable for something like a mutex. Instead, we encode the desired expiry as the value of
+// the mutex's key value and atomically delete when found to be expired.
 //
 // Mutexes with different names are unrelated. Mutexes with the same name from different plugins
 // are unrelated. Pick a unique name for each mutex your plugin requires.
@@ -46,46 +51,117 @@ type Mutex struct {
 	lock        sync.Mutex
 	stopRefresh chan bool
 	refreshDone chan bool
+
+	// lockExpiry tracks the expiration time of the lock when last locked. It is not guarded
+	// by a local mutex, since it is only read or written when the cluster lock is held.
+	lockExpiry time.Time
 }
 
-// NewMutex creates a mutex with the given name.
+// NewMutex creates a mutex with the given key name.
+//
+// Panics if key is empty.
 func NewMutex(pluginAPI MutexPluginAPI, key string) *Mutex {
-	key = mutexPrefix + key
-
 	return &Mutex{
 		pluginAPI: pluginAPI,
-		key:       key,
+		key:       makeLockKey(key),
 	}
+}
+
+// makeLockKey returns the prefixed key used to namespace mutex keys.
+func makeLockKey(key string) string {
+	if len(key) == 0 {
+		panic("must specify valid mutex key")
+	}
+
+	return mutexPrefix + key
+}
+
+// makeLockValue returns the encoded lock value for the given expiry timestamp.
+func makeLockValue(expiresAt time.Time) []byte {
+	return []byte(strconv.FormatInt(expiresAt.UnixNano(), 10))
+}
+
+// getLockValue decodes the given lock value into the expiry timestamp it potentially represents.
+func getLockValue(valueBytes []byte) (time.Time, error) {
+	if len(valueBytes) == 0 {
+		return time.Time{}, nil
+	}
+
+	value, err := strconv.ParseInt(string(valueBytes), 10, 64)
+	if err != nil {
+		return time.Time{}, errors.Wrap(err, "failed to parse mutex kv value")
+	}
+
+	return time.Unix(0, value), nil
 }
 
 // lock makes a single attempt to atomically lock the mutex, returning true only if successful.
 func (m *Mutex) tryLock() (bool, error) {
-	ok, err := m.pluginAPI.KVSetWithOptions(m.key, []byte{1}, model.PluginKVSetOptions{
-		Atomic:          true,
-		OldValue:        nil, // No existing key value.
-		ExpireInSeconds: int64(ttl / time.Second),
+	now := time.Now()
+	newLockExpiry := now.Add(ttl)
+
+	ok, appErr := m.pluginAPI.KVSetWithOptions(m.key, makeLockValue(newLockExpiry), model.PluginKVSetOptions{
+		Atomic:   true,
+		OldValue: nil, // No existing key value.
 	})
-	if err != nil {
-		return false, errors.Wrap(err, "failed to set mutex kv")
+	if appErr != nil {
+		return false, errors.Wrap(appErr, "failed to set mutex kv")
 	}
 
-	return ok, nil
+	if ok {
+		m.lockExpiry = newLockExpiry
+		return true, nil
+	}
+
+	// Check to see if the lock has expired.
+	valueBytes, appErr := m.pluginAPI.KVGet(m.key)
+	if appErr != nil {
+		return false, errors.Wrap(appErr, "failed to get mutex kv")
+	}
+	actualLockExpiry, err := getLockValue(valueBytes)
+	if err != nil {
+		return false, err
+	}
+
+	// It might have already been deleted.
+	if actualLockExpiry.IsZero() {
+		return false, nil
+	}
+
+	// It might still be valid.
+	if actualLockExpiry.After(now) {
+		return false, nil
+	}
+
+	// Atomically delete the expired lock and try again.
+	ok, appErr = m.pluginAPI.KVSetWithOptions(m.key, nil, model.PluginKVSetOptions{
+		Atomic:   true,
+		OldValue: valueBytes,
+	})
+	if err != nil {
+		return false, errors.Wrap(err, "failed to delete mutex kv")
+	}
+
+	return false, nil
 }
 
 // refreshLock rewrites the lock key value with a new expiry, returning true only if successful.
-//
-// Only call this while holding the lock.
 func (m *Mutex) refreshLock() error {
-	ok, err := m.pluginAPI.KVSetWithOptions(m.key, []byte{1}, model.PluginKVSetOptions{
-		Atomic:          true,
-		OldValue:        []byte{1},
-		ExpireInSeconds: int64(ttl / time.Second),
+	now := time.Now()
+
+	newLockExpiry := now.Add(ttl)
+
+	ok, err := m.pluginAPI.KVSetWithOptions(m.key, makeLockValue(newLockExpiry), model.PluginKVSetOptions{
+		Atomic:   true,
+		OldValue: makeLockValue(m.lockExpiry),
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed to refresh mutex kv")
 	} else if !ok {
 		return errors.New("unexpectedly failed to refresh mutex kv")
 	}
+
+	m.lockExpiry = newLockExpiry
 
 	return nil
 }

--- a/cluster/mutex.go
+++ b/cluster/mutex.go
@@ -165,7 +165,7 @@ func (m *Mutex) Lock() {
 	m.LockWithContext(context.Background())
 }
 
-// Lock locks m unless the context is cancelled. If the mutex is already locked by any plugin
+// LockWithContext locks m unless the context is cancelled. If the mutex is already locked by any plugin
 // instance, including the current one, the calling goroutine blocks until the mutex can be locked,
 // or the context is cancelled.
 //

--- a/cluster/mutex.go
+++ b/cluster/mutex.go
@@ -20,18 +20,6 @@ const (
 
 	// refreshInterval is the interval on which the mutex will be refreshed when locked
 	refreshInterval = ttl / 2
-
-	// minWaitInterval is the minimum amount of time to wait between locking attempts
-	minWaitInterval = 1 * time.Second
-
-	// maxWaitInterval is the maximum amount of time to wait between locking attempts
-	maxWaitInterval = 5 * time.Minute
-
-	// pollWaitInterval is the usual time to wait between unsuccessful locking attempts
-	pollWaitInterval = 1 * time.Second
-
-	// jitterWaitInterval is the amount of jitter to add when waiting to avoid thundering herds
-	jitterWaitInterval = minWaitInterval / 2
 )
 
 // MutexPluginAPI is the plugin API interface required to manage mutexes.

--- a/cluster/mutex.go
+++ b/cluster/mutex.go
@@ -52,20 +52,25 @@ type Mutex struct {
 // NewMutex creates a mutex with the given key name.
 //
 // Panics if key is empty.
-func NewMutex(pluginAPI MutexPluginAPI, key string) *Mutex {
+func NewMutex(pluginAPI MutexPluginAPI, key string) (*Mutex, error) {
+	key, err := makeLockKey(key)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Mutex{
 		pluginAPI: pluginAPI,
-		key:       makeLockKey(key),
-	}
+		key:       key,
+	}, nil
 }
 
 // makeLockKey returns the prefixed key used to namespace mutex keys.
-func makeLockKey(key string) string {
+func makeLockKey(key string) (string, error) {
 	if len(key) == 0 {
-		panic("must specify valid mutex key")
+		return "", errors.New("must specify valid mutex key")
 	}
 
-	return mutexPrefix + key
+	return mutexPrefix + key, nil
 }
 
 // lock makes a single attempt to atomically lock the mutex, returning true only if successful.

--- a/cluster/mutex_example_test.go
+++ b/cluster/mutex_example_test.go
@@ -9,7 +9,10 @@ func ExampleMutex() {
 	// Use p.API from your plugin instead.
 	pluginAPI := plugin.API(nil)
 
-	m := cluster.NewMutex(pluginAPI, "key")
+	m, err := cluster.NewMutex(pluginAPI, "key")
+	if err != nil {
+		panic(err)
+	}
 	m.Lock()
 	// critical section
 	m.Unlock()

--- a/cluster/mutex_test.go
+++ b/cluster/mutex_test.go
@@ -4,21 +4,74 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMakeLockKey(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		assert.Panics(t, func() {
+			makeLockKey("")
+		})
+	})
+
+	t.Run("not-empty", func(t *testing.T) {
+		testCases := map[string]string{
+			"key":   mutexPrefix + "key",
+			"other": mutexPrefix + "other",
+		}
+
+		for key, expected := range testCases {
+			actual := makeLockKey(key)
+			assert.Equal(t, expected, actual)
+		}
+	})
+}
+
+func TestLockValue(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		actual, err := getLockValue([]byte{})
+		require.NoError(t, err)
+		require.True(t, actual.IsZero())
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		actual, err := getLockValue([]byte("abc"))
+		require.Error(t, err)
+		require.True(t, actual.IsZero())
+	})
+
+	t.Run("successful", func(t *testing.T) {
+		testCases := []time.Time{
+			time.Now().Add(-15 * time.Second),
+			time.Now(),
+			time.Now().Add(15 * time.Second),
+		}
+
+		for _, testCase := range testCases {
+			t.Run(testCase.Format("Mon Jan 2 15:04:05 -0700 MST 2006"), func(t *testing.T) {
+				actual, err := getLockValue(makeLockValue(testCase))
+				require.NoError(t, err)
+				require.Equal(t, testCase.Truncate(0), actual.Truncate(0))
+			})
+		}
+	})
+}
 
 func lock(t *testing.T, m *Mutex) {
 	t.Helper()
 
 	done := make(chan bool)
 	go func() {
+		t.Helper()
+
 		defer close(done)
 		m.Lock()
 	}()
 
 	select {
-	case <-time.After(1 * time.Second):
+	case <-time.After(2 * time.Second):
 		require.Fail(t, "failed to lock mutex within 1 second")
 	case <-done:
 	}
@@ -29,6 +82,8 @@ func unlock(t *testing.T, m *Mutex, panics bool) {
 
 	done := make(chan bool)
 	go func() {
+		t.Helper()
+
 		defer close(done)
 		if panics {
 			assert.Panics(t, m.Unlock)
@@ -45,10 +100,18 @@ func unlock(t *testing.T, m *Mutex, panics bool) {
 }
 
 func TestMutex(t *testing.T) {
+	t.Parallel()
+
+	makeKey := func() string {
+		return model.NewId()
+	}
+
 	t.Run("successful lock/unlock cycle", func(t *testing.T) {
+		t.Parallel()
+
 		mockPluginAPI := newMockPluginAPI(t)
 
-		m := NewMutex(mockPluginAPI, "key")
+		m := NewMutex(mockPluginAPI, makeKey())
 		lock(t, m)
 		unlock(t, m, false)
 		lock(t, m)
@@ -56,16 +119,20 @@ func TestMutex(t *testing.T) {
 	})
 
 	t.Run("unlock when not locked", func(t *testing.T) {
+		t.Parallel()
+
 		mockPluginAPI := newMockPluginAPI(t)
 
-		m := NewMutex(mockPluginAPI, "key")
+		m := NewMutex(mockPluginAPI, makeKey())
 		unlock(t, m, true)
 	})
 
 	t.Run("blocking lock", func(t *testing.T) {
+		t.Parallel()
+
 		mockPluginAPI := newMockPluginAPI(t)
 
-		m := NewMutex(mockPluginAPI, "key")
+		m := NewMutex(mockPluginAPI, makeKey())
 		lock(t, m)
 
 		done := make(chan bool)
@@ -90,9 +157,11 @@ func TestMutex(t *testing.T) {
 	})
 
 	t.Run("failed lock", func(t *testing.T) {
+		t.Parallel()
+
 		mockPluginAPI := newMockPluginAPI(t)
 
-		m := NewMutex(mockPluginAPI, "key")
+		m := NewMutex(mockPluginAPI, makeKey())
 
 		mockPluginAPI.setFailing(true)
 
@@ -118,9 +187,11 @@ func TestMutex(t *testing.T) {
 	})
 
 	t.Run("failed unlock", func(t *testing.T) {
+		t.Parallel()
+
 		mockPluginAPI := newMockPluginAPI(t)
 
-		m := NewMutex(mockPluginAPI, "key")
+		m := NewMutex(mockPluginAPI, makeKey())
 		lock(t, m)
 
 		mockPluginAPI.setFailing(true)
@@ -135,15 +206,17 @@ func TestMutex(t *testing.T) {
 	})
 
 	t.Run("discrete keys", func(t *testing.T) {
+		t.Parallel()
+
 		mockPluginAPI := newMockPluginAPI(t)
 
-		m1 := NewMutex(mockPluginAPI, "key1")
+		m1 := NewMutex(mockPluginAPI, makeKey())
 		lock(t, m1)
 
-		m2 := NewMutex(mockPluginAPI, "key2")
+		m2 := NewMutex(mockPluginAPI, makeKey())
 		lock(t, m2)
 
-		m3 := NewMutex(mockPluginAPI, "key3")
+		m3 := NewMutex(mockPluginAPI, makeKey())
 		lock(t, m3)
 
 		unlock(t, m1, false)
@@ -153,5 +226,90 @@ func TestMutex(t *testing.T) {
 
 		unlock(t, m2, false)
 		unlock(t, m1, false)
+	})
+
+	t.Run("expiring lock", func(t *testing.T) {
+		t.Parallel()
+
+		mockPluginAPI := newMockPluginAPI(t)
+
+		key := makeKey()
+		m := NewMutex(mockPluginAPI, key)
+
+		// Simulate lock expiring in 5 seconds
+		now := time.Now()
+		ok, appErr := mockPluginAPI.KVSetWithOptions(mutexPrefix+key, makeLockValue(now.Add(5*time.Second)), model.PluginKVSetOptions{})
+		require.Nil(t, appErr)
+		require.True(t, ok)
+
+		done1 := make(chan bool)
+		go func() {
+			defer close(done1)
+			m.Lock()
+		}()
+
+		done2 := make(chan bool)
+		go func() {
+			defer close(done2)
+			m.Lock()
+		}()
+
+		select {
+		case <-time.After(1 * time.Second):
+		case <-done1:
+			require.Fail(t, "first goroutine should not have locked yet")
+		case <-done2:
+			require.Fail(t, "second goroutine should not have locked yet")
+		}
+
+		select {
+		case <-time.After(4*time.Second + pollWaitInterval*2):
+			require.Fail(t, "some goroutine should have locked after expiry")
+		case <-done1:
+			m.Unlock()
+			select {
+			case <-done2:
+			case <-time.After(pollWaitInterval * 2):
+				require.Fail(t, "second goroutine should have locked")
+			}
+
+		case <-done2:
+			m.Unlock()
+			select {
+			case <-done2:
+			case <-time.After(pollWaitInterval * 2):
+				require.Fail(t, "first goroutine should have locked")
+			}
+		}
+	})
+
+	t.Run("held lock does not expire", func(t *testing.T) {
+		t.Parallel()
+
+		mockPluginAPI := newMockPluginAPI(t)
+
+		m := NewMutex(mockPluginAPI, makeKey())
+
+		m.Lock()
+
+		done := make(chan bool)
+		go func() {
+			defer close(done)
+			m.Lock()
+		}()
+
+		select {
+		case <-time.After(ttl + pollWaitInterval*2):
+		case <-done:
+			require.Fail(t, "goroutine should not have locked")
+		}
+
+		m.Unlock()
+
+		select {
+		case <-time.After(pollWaitInterval * 2):
+			require.Fail(t, "goroutine should have locked after expiry")
+		case <-done:
+		}
 	})
 }

--- a/cluster/mutex_test.go
+++ b/cluster/mutex_test.go
@@ -10,11 +10,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func mustMakeLockKey(key string) string {
+	key, err := makeLockKey(key)
+	if err != nil {
+		panic(err)
+	}
+
+	return key
+}
+
+func mustNewMutex(pluginAPI MutexPluginAPI, key string) *Mutex {
+	m, err := NewMutex(pluginAPI, key)
+	if err != nil {
+		panic(err)
+	}
+
+	return m
+}
+
 func TestMakeLockKey(t *testing.T) {
-	t.Run("empty", func(t *testing.T) {
-		assert.Panics(t, func() {
-			makeLockKey("")
-		})
+	t.Run("fails when empty", func(t *testing.T) {
+		key, err := makeLockKey("")
+		assert.Error(t, err)
+		assert.Empty(t, key)
 	})
 
 	t.Run("not-empty", func(t *testing.T) {
@@ -24,7 +42,8 @@ func TestMakeLockKey(t *testing.T) {
 		}
 
 		for key, expected := range testCases {
-			actual := makeLockKey(key)
+			actual, err := makeLockKey(key)
+			require.NoError(t, err)
 			assert.Equal(t, expected, actual)
 		}
 	})
@@ -82,7 +101,7 @@ func TestMutex(t *testing.T) {
 
 		mockPluginAPI := newMockPluginAPI(t)
 
-		m := NewMutex(mockPluginAPI, makeKey())
+		m := mustNewMutex(mockPluginAPI, makeKey())
 		lock(t, m)
 		unlock(t, m, false)
 		lock(t, m)
@@ -94,7 +113,7 @@ func TestMutex(t *testing.T) {
 
 		mockPluginAPI := newMockPluginAPI(t)
 
-		m := NewMutex(mockPluginAPI, makeKey())
+		m := mustNewMutex(mockPluginAPI, makeKey())
 		unlock(t, m, true)
 	})
 
@@ -103,7 +122,7 @@ func TestMutex(t *testing.T) {
 
 		mockPluginAPI := newMockPluginAPI(t)
 
-		m := NewMutex(mockPluginAPI, makeKey())
+		m := mustNewMutex(mockPluginAPI, makeKey())
 		lock(t, m)
 
 		done := make(chan bool)
@@ -132,7 +151,7 @@ func TestMutex(t *testing.T) {
 
 		mockPluginAPI := newMockPluginAPI(t)
 
-		m := NewMutex(mockPluginAPI, makeKey())
+		m := mustNewMutex(mockPluginAPI, makeKey())
 
 		mockPluginAPI.setFailing(true)
 
@@ -162,7 +181,8 @@ func TestMutex(t *testing.T) {
 
 		mockPluginAPI := newMockPluginAPI(t)
 
-		m := NewMutex(mockPluginAPI, makeKey())
+		key := makeKey()
+		m := mustNewMutex(mockPluginAPI, key)
 		lock(t, m)
 
 		mockPluginAPI.setFailing(true)
@@ -181,13 +201,13 @@ func TestMutex(t *testing.T) {
 
 		mockPluginAPI := newMockPluginAPI(t)
 
-		m1 := NewMutex(mockPluginAPI, makeKey())
+		m1 := mustNewMutex(mockPluginAPI, makeKey())
 		lock(t, m1)
 
-		m2 := NewMutex(mockPluginAPI, makeKey())
+		m2 := mustNewMutex(mockPluginAPI, makeKey())
 		lock(t, m2)
 
-		m3 := NewMutex(mockPluginAPI, makeKey())
+		m3 := mustNewMutex(mockPluginAPI, makeKey())
 		lock(t, m3)
 
 		unlock(t, m1, false)
@@ -204,7 +224,8 @@ func TestMutex(t *testing.T) {
 
 		mockPluginAPI := newMockPluginAPI(t)
 
-		m := NewMutex(mockPluginAPI, makeKey())
+		key := makeKey()
+		m := mustNewMutex(mockPluginAPI, key)
 
 		m.Lock()
 
@@ -236,7 +257,7 @@ func TestMutex(t *testing.T) {
 
 		mockPluginAPI := newMockPluginAPI(t)
 
-		m := NewMutex(mockPluginAPI, makeKey())
+		m := mustNewMutex(mockPluginAPI, makeKey())
 
 		m.Lock()
 

--- a/cluster/wait.go
+++ b/cluster/wait.go
@@ -5,6 +5,20 @@ import (
 	"time"
 )
 
+const (
+	// minWaitInterval is the minimum amount of time to wait between locking attempts
+	minWaitInterval = 1 * time.Second
+
+	// maxWaitInterval is the maximum amount of time to wait between locking attempts
+	maxWaitInterval = 5 * time.Minute
+
+	// pollWaitInterval is the usual time to wait between unsuccessful locking attempts
+	pollWaitInterval = 1 * time.Second
+
+	// jitterWaitInterval is the amount of jitter to add when waiting to avoid thundering herds
+	jitterWaitInterval = minWaitInterval / 2
+)
+
 // nextWaitInterval determines how long to wait until the next lock retry.
 func nextWaitInterval(lastWaitInterval time.Duration, err error) time.Duration {
 	nextWaitInterval := lastWaitInterval


### PR DESCRIPTION
#### Summary
This branches off https://github.com/mattermost/mattermost-plugin-api/pull/33 to add support for locking with a context (and thus implicitly supporting lock cancellation, "try lock" semantics, etc.).

I opted not to merge directly to `master` given the rework happening in that active PR.