### PR TITLE
MM-23163 - KV.Get() for a non-existent key should not return an error

### DIFF
--- a/kv.go
+++ b/kv.go
@@ -150,6 +150,10 @@ func (k *KVService) Get(key string, o interface{}) error {
 		return normalizeAppErr(appErr)
 	}
 
+	if len(data) == 0 {
+		return nil
+	}
+
 	if bytesOut, ok := o.(*[]byte); ok {
 		*bytesOut = data
 		return nil

--- a/kv_test.go
+++ b/kv_test.go
@@ -210,6 +210,19 @@ func TestGet(t *testing.T) {
 	assert.Equal(t, "2", out)
 }
 
+func TestGetNilKey(t *testing.T) {
+	api := &plugintest.API{}
+	defer api.AssertExpectations(t)
+	client := pluginapi.NewClient(api)
+
+	api.On("KVGet", "1").Return(nil, nil)
+
+	var out string
+	err := client.KV.Get("1", &out)
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
 func TestGetInBytes(t *testing.T) {
 	api := &plugintest.API{}
 	defer api.AssertExpectations(t)


### PR DESCRIPTION

#### Summary
MM-23163 - KV.Get() for a non-existant key should not return an error

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-23163