### PR TITLE
Support externally defined wait intervals

### DIFF
--- a/cluster/job_example_test.go
+++ b/cluster/job_example_test.go
@@ -14,7 +14,7 @@ func ExampleSchedule() {
 		// periodic work to do
 	}
 
-	job, err := Schedule(pluginAPI, "key", JobConfig{Interval: 5 * time.Minute}, callback)
+	job, err := Schedule(pluginAPI, "key", MakeWaitForInterval(5*time.Minute), callback)
 	if err != nil {
 		panic("failed to schedule job")
 	}

--- a/cluster/job_test.go
+++ b/cluster/job_test.go
@@ -11,22 +11,267 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMakeWaitForInterval(t *testing.T) {
+	t.Run("panics on invalid interval", func(t *testing.T) {
+		assert.Panics(t, func() {
+			MakeWaitForInterval(0)
+		})
+	})
+
+	const neverRun = -1 * time.Second
+
+	testCases := []struct {
+		Description  string
+		Interval     time.Duration
+		LastFinished time.Duration
+		Expected     time.Duration
+	}{
+		{
+			"never run, 5 minutes",
+			5 * time.Minute,
+			neverRun,
+			0,
+		},
+		{
+			"run 1 minute ago, 5 minutes",
+			5 * time.Minute,
+			-1 * time.Minute,
+			4 * time.Minute,
+		},
+		{
+			"run 2 minutes ago, 5 minutes",
+			5 * time.Minute,
+			-2 * time.Minute,
+			3 * time.Minute,
+		},
+		{
+			"run 4 minutes 30 seconds ago, 5 minutes",
+			5 * time.Minute,
+			-4*time.Minute - 30*time.Second,
+			30 * time.Second,
+		},
+		{
+			"run 4 minutes 59 seconds ago, 5 minutes",
+			5 * time.Minute,
+			-4*time.Minute - 59*time.Second,
+			1 * time.Second,
+		},
+		{
+			"never run, 1 hour",
+			1 * time.Hour,
+			neverRun,
+			0,
+		},
+		{
+			"run 1 minute ago, 1 hour",
+			1 * time.Hour,
+			-1 * time.Minute,
+			59 * time.Minute,
+		},
+		{
+			"run 20 minutes ago, 1 hour",
+			1 * time.Hour,
+			-20 * time.Minute,
+			40 * time.Minute,
+		},
+		{
+			"run 55 minutes 30 seconds ago, 1 hour",
+			1 * time.Hour,
+			-55*time.Minute - 30*time.Second,
+			4*time.Minute + 30*time.Second,
+		},
+		{
+			"run 59 minutes 59 seconds ago, 1 hour",
+			1 * time.Hour,
+			-59*time.Minute - 59*time.Second,
+			1 * time.Second,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Description, func(t *testing.T) {
+			now := time.Now()
+
+			var lastFinished time.Time
+			if testCase.LastFinished != neverRun {
+				lastFinished = now.Add(testCase.LastFinished)
+			}
+
+			actual := MakeWaitForInterval(testCase.Interval)(now, jobMetadata{
+				LastFinished: lastFinished,
+			})
+			assert.Equal(t, testCase.Expected, actual)
+		})
+	}
+}
+
+func TestMakeWaitForRoundedInterval(t *testing.T) {
+	t.Run("panics on invalid interval", func(t *testing.T) {
+		assert.Panics(t, func() {
+			MakeWaitForRoundedInterval(0)
+		})
+	})
+
+	const neverRun = -1 * time.Second
+	topOfTheHour := time.Now().Truncate(1 * time.Hour)
+	topOfTheDay := time.Now().Truncate(24 * time.Hour)
+
+	testCases := []struct {
+		Description  string
+		Interval     time.Duration
+		Now          time.Time
+		LastFinished time.Duration
+		Expected     time.Duration
+	}{
+		{
+			"5 minutes, top of the hour, never run",
+			5 * time.Minute,
+			topOfTheHour,
+			neverRun,
+			0,
+		},
+		{
+			"5 minutes, top of the hour less 1 minute, never run",
+			5 * time.Minute,
+			topOfTheHour.Add(-1 * time.Minute),
+			neverRun,
+			0,
+		},
+		{
+			"5 minutes, top of the hour less 1 minute, run 1 minute ago",
+			5 * time.Minute,
+			topOfTheHour.Add(-1 * time.Minute),
+			-1 * time.Minute,
+			1 * time.Minute,
+		},
+		{
+			"5 minutes, top of the hour plus 1 minute, run 2 minutes ago",
+			5 * time.Minute,
+			topOfTheHour.Add(1 * time.Minute),
+			-2 * time.Minute,
+			0,
+		},
+		{
+			"5 minutes, top of the hour plus 1 minute, run 30 seconds ago",
+			5 * time.Minute,
+			topOfTheHour.Add(1 * time.Minute),
+			-30 * time.Second,
+			4 * time.Minute,
+		},
+		{
+			"5 minutes, top of the hour plus 7 minutes, run 30 seconds ago",
+			5 * time.Minute,
+			topOfTheHour.Add(7 * time.Minute),
+			-30 * time.Second,
+			3 * time.Minute,
+		},
+		{
+			"30 minutes, top of the hour, never run",
+			30 * time.Minute,
+			topOfTheHour,
+			neverRun,
+			0,
+		},
+		{
+			"30 minutes, top of the hour less 1 minute, never run",
+			30 * time.Minute,
+			topOfTheHour.Add(-1 * time.Minute),
+			neverRun,
+			0,
+		},
+		{
+			"30 minutes, top of the hour less 1 minute, run 1 minute ago",
+			30 * time.Minute,
+			topOfTheHour.Add(-1 * time.Minute),
+			-1 * time.Minute,
+			1 * time.Minute,
+		},
+		{
+			"30 minutes, top of the hour plus 1 minute, run 2 minutes ago",
+			30 * time.Minute,
+			topOfTheHour.Add(1 * time.Minute),
+			-2 * time.Minute,
+			0,
+		},
+		{
+			"30 minutes, top of the hour plus 1 minute, run 30 seconds ago",
+			30 * time.Minute,
+			topOfTheHour.Add(1 * time.Minute),
+			-30 * time.Second,
+			29 * time.Minute,
+		},
+		{
+			"30 minutes, top of the hour plus 7 minutes, run 30 seconds ago",
+			30 * time.Minute,
+			topOfTheHour.Add(7 * time.Minute),
+			-30 * time.Second,
+			23 * time.Minute,
+		},
+		{
+			"24 hours, top of the day, never run",
+			24 * time.Hour,
+			topOfTheDay,
+			neverRun,
+			0,
+		},
+		{
+			"24 hours, top of the day less 1 minute, never run",
+			24 * time.Hour,
+			topOfTheDay.Add(-1 * time.Minute),
+			neverRun,
+			0,
+		},
+		{
+			"24 hours, top of the day less 1 minute, run 1 minute ago",
+			24 * time.Hour,
+			topOfTheDay.Add(-1 * time.Minute),
+			-1 * time.Minute,
+			1 * time.Minute,
+		},
+		{
+			"24 hours, top of the day plus 1 minute, run 2 minutes ago",
+			24 * time.Hour,
+			topOfTheDay.Add(1 * time.Minute),
+			-2 * time.Minute,
+			0,
+		},
+		{
+			"24 hours, top of the day plus 1 minute, run 30 seconds ago",
+			24 * time.Hour,
+			topOfTheDay.Add(1 * time.Minute),
+			-30 * time.Second,
+			23*time.Hour + 59*time.Minute,
+		},
+		{
+			"24 hours, top of the day plus 7 minutes, run 30 seconds ago",
+			24 * time.Hour,
+			topOfTheDay.Add(7 * time.Minute),
+			-30 * time.Second,
+			23*time.Hour + 53*time.Minute,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Description, func(t *testing.T) {
+			var lastFinished time.Time
+			if testCase.LastFinished != neverRun {
+				lastFinished = testCase.Now.Add(testCase.LastFinished)
+			}
+
+			actual := MakeWaitForRoundedInterval(testCase.Interval)(testCase.Now, jobMetadata{
+				LastFinished: lastFinished,
+			})
+			assert.Equal(t, testCase.Expected, actual)
+		})
+	}
+}
+
 func TestSchedule(t *testing.T) {
 	t.Parallel()
 
 	makeKey := func() string {
 		return model.NewId()
 	}
-
-	t.Run("invalid interval", func(t *testing.T) {
-		t.Parallel()
-
-		mockPluginAPI := newMockPluginAPI(t)
-
-		job, err := Schedule(mockPluginAPI, makeKey(), JobConfig{}, func() {})
-		require.Error(t, err, "must specify non-zero job config interval")
-		require.Nil(t, job)
-	})
 
 	t.Run("single-threaded", func(t *testing.T) {
 		t.Parallel()
@@ -38,7 +283,7 @@ func TestSchedule(t *testing.T) {
 			atomic.AddInt32(count, 1)
 		}
 
-		job, err := Schedule(mockPluginAPI, makeKey(), JobConfig{Interval: 100 * time.Millisecond}, callback)
+		job, err := Schedule(mockPluginAPI, makeKey(), MakeWaitForInterval(100*time.Millisecond), callback)
 		require.NoError(t, err)
 		require.NotNil(t, job)
 
@@ -71,7 +316,7 @@ func TestSchedule(t *testing.T) {
 		key := makeKey()
 
 		for i := 0; i < 3; i++ {
-			job, err := Schedule(mockPluginAPI, key, JobConfig{Interval: 100 * time.Millisecond}, callback)
+			job, err := Schedule(mockPluginAPI, key, MakeWaitForInterval(100*time.Millisecond), callback)
 			require.NoError(t, err)
 			require.NotNil(t, job)
 
@@ -131,7 +376,7 @@ func TestSchedule(t *testing.T) {
 				callback = callbackB
 			}
 
-			job, err := Schedule(mockPluginAPI, key, JobConfig{Interval: 100 * time.Millisecond}, callback)
+			job, err := Schedule(mockPluginAPI, key, MakeWaitForInterval(100*time.Millisecond), callback)
 			require.NoError(t, err)
 			require.NotNil(t, job)
 


### PR DESCRIPTION
#### Summary
Parameterize the function for computing a job's next wait interval, and provide two implementations by default:
* `MakeWaitForInterval`: the existing semantics of spacing runs by a configured interval
* `MakeWaitForRoundedInterval`: a variation of the above that rounds (really, truncates) to that interval, so as to consistently run, say, every 5 minutes on 0:00, 0:05, 0:10, ... even if the job is paused for some reason. In other words, it won't drift out of sync relative to the clock. It doesn't guarantee /never/ running less than the interval, since if it's been longer than the required interval it just runs right away.

@mickmister, hopefully this addresses your needs with the MS calendar plugin: but if not, hopefully you can provide your own wait interval function. Let me know if you think the existing algorithm can/should be tweaked.

Also, apologies for the nested pull requests here -- I'll rebase as necessary, but these are all building off each other. I'll clean this up as we merge in.