### PR TITLE
MM-24456 - CreateChannel followed by AddChannelMember is racy when a replica exists

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -101,7 +101,7 @@ func (c *ChannelService) Create(channel *model.Channel) error {
 
 	*channel = *createdChannel
 
-	return c.waitForChannelCreation(createdChannel.Id)
+	return c.waitForChannelCreation(channel.Id)
 }
 
 // Update updates a channel.
@@ -218,6 +218,10 @@ func (c *ChannelService) UpdateChannelMemberNotifications(channelID, userID stri
 }
 
 func (c *ChannelService) waitForChannelCreation(channelID string) error {
+	if len(c.api.GetConfig().SqlSettings.DataSourceReplicas) == 0 {
+		return nil
+	}
+
 	now := time.Now()
 
 	for time.Since(now) < 1500*time.Millisecond {

--- a/channel.go
+++ b/channel.go
@@ -1,8 +1,12 @@
 package pluginapi
 
 import (
+	"net/http"
+	"time"
+
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/pkg/errors"
 )
 
 // ChannelService exposes methods to manipulate channels.
@@ -97,7 +101,7 @@ func (c *ChannelService) Create(channel *model.Channel) error {
 
 	*channel = *createdChannel
 
-	return nil
+	return c.waitForChannelCreation(createdChannel.Id)
 }
 
 // Update updates a channel.
@@ -211,6 +215,23 @@ func (c *ChannelService) UpdateChannelMemberNotifications(channelID, userID stri
 	channelMember, appErr := c.api.UpdateChannelMemberNotifications(channelID, userID, notifications)
 
 	return channelMember, normalizeAppErr(appErr)
+}
+
+func (c *ChannelService) waitForChannelCreation(channelID string) error {
+	now := time.Now()
+
+	for time.Since(now) < 1500*time.Millisecond {
+		time.Sleep(100 * time.Millisecond)
+
+		if _, err := c.api.GetChannel(channelID); err == nil {
+			// Channel found
+			return nil
+		} else if err.StatusCode != http.StatusNotFound {
+			return err
+		}
+	}
+
+	return errors.Errorf("giving up waiting for channel creation, channelID=%s", channelID)
 }
 
 func channelMembersToChannelMemberSlice(cm *model.ChannelMembers) []*model.ChannelMember {

--- a/channel_test.go
+++ b/channel_test.go
@@ -106,3 +106,84 @@ func TestGetPublicTeamChannels(t *testing.T) {
 		require.Len(t, channels, 0)
 	})
 }
+
+func TestCreateChannel(t *testing.T) {
+	t.Run("create channel and wait once", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+		client := pluginapi.NewClient(api)
+
+		c := &model.Channel{
+			Id:          model.NewId(),
+			Name:        "name",
+			DisplayName: "displayname",
+		}
+		api.On("CreateChannel", c).Return(c, nil).Once()
+		api.On("GetChannel", c.Id).Return(c, nil).Once()
+
+		err := client.Channel.Create(c)
+		require.NoError(t, err)
+	})
+
+	t.Run("create channel and wait multiple times", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+		client := pluginapi.NewClient(api)
+
+		c := &model.Channel{
+			Id:          model.NewId(),
+			Name:        "name",
+			DisplayName: "displayname",
+		}
+		api.On("CreateChannel", c).Return(c, nil).Once()
+
+		notFoundErr := model.NewAppError("", "", nil, "", http.StatusNotFound)
+		api.On("GetChannel", c.Id).Return(c, notFoundErr).Times(3)
+		api.On("GetChannel", c.Id).Return(c, nil).Times(1)
+
+		err := client.Channel.Create(c)
+		require.NoError(t, err)
+	})
+
+	t.Run("create channel, wait multiple times and return error", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+		client := pluginapi.NewClient(api)
+
+		c := &model.Channel{
+			Id:          model.NewId(),
+			Name:        "name",
+			DisplayName: "displayname",
+		}
+		api.On("CreateChannel", c).Return(c, nil).Once()
+
+		notFoundErr := model.NewAppError("", "", nil, "", http.StatusNotFound)
+		api.On("GetChannel", c.Id).Return(c, notFoundErr).Times(3)
+
+		otherErr := model.NewAppError("", "", nil, "", http.StatusInternalServerError)
+		api.On("GetChannel", c.Id).Return(c, otherErr).Times(1)
+
+		err := client.Channel.Create(c)
+		require.Error(t, err)
+	})
+
+	t.Run("create channel, give up waiting", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+		client := pluginapi.NewClient(api)
+
+		c := &model.Channel{
+			Id:          model.NewId(),
+			Name:        "name",
+			DisplayName: "displayname",
+		}
+		api.On("CreateChannel", c).Return(c, nil).Once()
+
+		notFoundErr := model.NewAppError("", "", nil, "", http.StatusNotFound)
+		api.On("GetChannel", c.Id).Return(c, notFoundErr)
+
+		err := client.Channel.Create(c)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "giving up waiting")
+	})
+}

--- a/channel_test.go
+++ b/channel_test.go
@@ -108,10 +108,40 @@ func TestGetPublicTeamChannels(t *testing.T) {
 }
 
 func TestCreateChannel(t *testing.T) {
+	t.Run("create channel with no replicas", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+		client := pluginapi.NewClient(api)
+
+		config := &model.Config{
+			SqlSettings: model.SqlSettings{
+				DataSourceReplicas: []string{},
+			},
+		}
+		api.On("GetConfig").Return(config).Once()
+
+		c := &model.Channel{
+			Id:          model.NewId(),
+			Name:        "name",
+			DisplayName: "displayname",
+		}
+		api.On("CreateChannel", c).Return(c, nil).Once()
+
+		err := client.Channel.Create(c)
+		require.NoError(t, err)
+	})
+
 	t.Run("create channel and wait once", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
 		client := pluginapi.NewClient(api)
+
+		config := &model.Config{
+			SqlSettings: model.SqlSettings{
+				DataSourceReplicas: []string{"replica1"},
+			},
+		}
+		api.On("GetConfig").Return(config).Once()
 
 		c := &model.Channel{
 			Id:          model.NewId(),
@@ -129,6 +159,13 @@ func TestCreateChannel(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
 		client := pluginapi.NewClient(api)
+
+		config := &model.Config{
+			SqlSettings: model.SqlSettings{
+				DataSourceReplicas: []string{"replica1"},
+			},
+		}
+		api.On("GetConfig").Return(config).Once()
 
 		c := &model.Channel{
 			Id:          model.NewId(),
@@ -149,6 +186,13 @@ func TestCreateChannel(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
 		client := pluginapi.NewClient(api)
+
+		config := &model.Config{
+			SqlSettings: model.SqlSettings{
+				DataSourceReplicas: []string{"replica1"},
+			},
+		}
+		api.On("GetConfig").Return(config).Once()
 
 		c := &model.Channel{
 			Id:          model.NewId(),
@@ -171,6 +215,13 @@ func TestCreateChannel(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
 		client := pluginapi.NewClient(api)
+
+		config := &model.Config{
+			SqlSettings: model.SqlSettings{
+				DataSourceReplicas: []string{"replica1"},
+			},
+		}
+		api.On("GetConfig").Return(config).Once()
 
 		c := &model.Channel{
 			Id:          model.NewId(),


### PR DESCRIPTION
#### Summary
Calling `pluginAPI.AddUserToChannel(...)` can lead to a race condition if it is proceeded by `CreateChannel` as `AddUserToChannel` first calls [`api.GetChannel`](https://github.com/mattermost/mattermost-server/blob/aa47b4633f18eed917c70263d139376f15d8778c/app/plugin_api.go#L422) to validate channel before adding the user. `GetChannel` uses a replica if one exists and if data hasn't reached consistency, this call returns a `channel not found error`. Solution is to wait for channel creation to propagate through replicas before returning success from `Channel.Create(..)`

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-24456

