### PR TITLE
MM-25702 - Increase MaxOpenConns when creating DB handles in mattermost-plugin-api

### DIFF
--- a/store.go
+++ b/store.go
@@ -27,7 +27,7 @@ type StoreService struct {
 	replicaDB *sql.DB
 }
 
-// GetMasterDB Gets the master database handle.
+// GetMasterDB gets the master database handle.
 //
 // Minimum server version: 5.16
 func (s *StoreService) GetMasterDB() (*sql.DB, error) {
@@ -41,7 +41,7 @@ func (s *StoreService) GetMasterDB() (*sql.DB, error) {
 	return s.masterDB, nil
 }
 
-// GetReplicaDB Gets the replica database handle.
+// GetReplicaDB gets the replica database handle.
 // Returns masterDB if a replica is not configured.
 //
 // Minimum server version: 5.16

--- a/store.go
+++ b/store.go
@@ -27,7 +27,7 @@ type StoreService struct {
 	replicaDB *sql.DB
 }
 
-// Gets the master database handle.
+// GetMasterDB Gets the master database handle.
 //
 // Minimum server version: 5.16
 func (s *StoreService) GetMasterDB() (*sql.DB, error) {
@@ -41,7 +41,7 @@ func (s *StoreService) GetMasterDB() (*sql.DB, error) {
 	return s.masterDB, nil
 }
 
-// Gets the replica database handle.
+// GetReplicaDB Gets the replica database handle.
 // Returns masterDB if a replica is not configured.
 //
 // Minimum server version: 5.16
@@ -128,8 +128,7 @@ func setupConnection(dataSourceName string, settings model.SqlSettings) (*sql.DB
 		return nil, errors.Wrap(err, "failed to open SQL connection")
 	}
 
-	// Set at most 2 connections for plugins
-	db.SetMaxOpenConns(2)
+	db.SetMaxOpenConns(15)
 	db.SetMaxIdleConns(2)
 	db.SetConnMaxLifetime(time.Duration(*settings.ConnMaxLifetimeMilliseconds) * time.Millisecond)
 


### PR DESCRIPTION
#### Summary
Corey had mentioned during the Incident Response architecture review meeting that maximum `2` open connections for each plugin seems low. This is to bump that to a reasonable number compared to the default value we use in the server, which is [`300`](https://github.com/mattermost/mattermost-server/blob/e6bbb4bd7abf50c9bb685d1326c3fc7556aa93fb/model/config.go#L1009). Bumping to a 5% of the default value i.e. `15` connections. Making this change since it's a quick change so we don't have to worry about it later.

Also used https://www.alexedwards.net/blog/configuring-sqldb as a reference, which suggests `25` per a medium sized application.


#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-25702

