### PR TITLE
MM-23502: update EnsureBot

### DIFF
--- a/botensure.go
+++ b/botensure.go
@@ -108,9 +108,21 @@ func (b *BotService) ensureBot(bot *model.Bot) (retBotID string, retErr error) {
 		return "", errors.Wrap(kvGetErr, "failed to get bot")
 	}
 
-	// If the bot has already been created, there is nothing to do.
+	// If the bot has already been created, use it
 	if botIDBytes != nil {
 		botID := string(botIDBytes)
+
+		// ensure existing bot is synced with what is being created
+		botPatch := &model.BotPatch{
+			Username:    &bot.Username,
+			DisplayName: &bot.DisplayName,
+			Description: &bot.Description,
+		}
+
+		if _, err := b.api.PatchBot(botID, botPatch); err != nil {
+			return "", errors.Wrap(err, "failed to patch bot")
+		}
+
 		return botID, nil
 	}
 


### PR DESCRIPTION
#### Summary
This effectively cherry-picks https://github.com/mattermost/mattermost-server/pull/14103 into the plugin api wrapper, in anticipation of removing the helpers altogether in a future v6.0. Bringing over the missing unit tests as well.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-23502