### PR TITLE
[GH-14939] Set defaults on API Config

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -23,14 +23,20 @@ func (c *ConfigurationService) LoadPluginConfiguration(dest interface{}) error {
 //
 // Minimum server version: 5.2
 func (c *ConfigurationService) GetConfig() *model.Config {
-	return c.api.GetConfig()
+	cfg := c.api.GetConfig()
+	cfg.SetDefaults()
+
+	return cfg
 }
 
 // GetUnsanitizedConfig fetches the currently persisted config without removing secrets.
 //
 // Minimum server version: 5.16
 func (c *ConfigurationService) GetUnsanitizedConfig() *model.Config {
-	return c.api.GetUnsanitizedConfig()
+	cfg := c.api.GetUnsanitizedConfig()
+	cfg.SetDefaults()
+
+	return cfg
 }
 
 // SaveConfig sets the given config and persists the changes

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -1,14 +1,14 @@
 package pluginapi
 
 import (
+	"testing"
+
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestConfigurationService_GetConfig(t *testing.T) {
-
 	t.Run("success - set defaults in config", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
@@ -23,11 +23,9 @@ func TestConfigurationService_GetConfig(t *testing.T) {
 
 		require.Equal(t, defaultConfig, cfg)
 	})
-
 }
 
 func TestConfigurationService_GetUnsanitizedConfig(t *testing.T) {
-
 	t.Run("success - set defaults in unsanitized config", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
@@ -42,5 +40,4 @@ func TestConfigurationService_GetUnsanitizedConfig(t *testing.T) {
 
 		require.Equal(t, defaultConfig, cfg)
 	})
-
 }

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -1,0 +1,46 @@
+package pluginapi
+
+import (
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestConfigurationService_GetConfig(t *testing.T) {
+
+	t.Run("success - set defaults in config", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+		configurationSvc := ConfigurationService{api: api}
+
+		defaultConfig := &model.Config{}
+		defaultConfig.SetDefaults()
+
+		api.On("GetConfig").Return(&model.Config{})
+
+		cfg := configurationSvc.GetConfig()
+
+		require.Equal(t, defaultConfig, cfg)
+	})
+
+}
+
+func TestConfigurationService_GetUnsanitizedConfig(t *testing.T) {
+
+	t.Run("success - set defaults in unsanitized config", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+		configurationSvc := ConfigurationService{api: api}
+
+		defaultConfig := &model.Config{}
+		defaultConfig.SetDefaults()
+
+		api.On("GetUnsanitizedConfig").Return(&model.Config{})
+
+		cfg := configurationSvc.GetUnsanitizedConfig()
+
+		require.Equal(t, defaultConfig, cfg)
+	})
+
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Add calls to `Config.SetDefaults()` before returning configuration in `ConfigurationService`, to prevent config from containing `nil` values.


#### Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/14939
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

