### PR TITLE
To be consistent with the rest of Mattermost telemetry, the user's ID…

### DIFF
--- a/experimental/telemetry/tracker.go
+++ b/experimental/telemetry/tracker.go
@@ -93,6 +93,6 @@ func (t *tracker) TrackEvent(event string, properties map[string]interface{}) {
 }
 
 func (t *tracker) TrackUserEvent(event, userID string, properties map[string]interface{}) {
-	properties["UserID"] = userID
+	properties["UserActualID"] = userID
 	t.TrackEvent(event, properties)
 }


### PR DESCRIPTION
… should be captured as 'UserActualID'.

#### Summary
To be consistent with the rest of Mattermost telemetry, the user's ID should be captured as 'UserActualID'.

