### PR TITLE
Add fallback to slack attachments and add missing comments

### DIFF
--- a/experimental/flow/steps/empty_step.go
+++ b/experimental/flow/steps/empty_step.go
@@ -1,6 +1,8 @@
 package steps
 
 import (
+	"fmt"
+
 	"github.com/mattermost/mattermost-plugin-api/experimental/freetextfetcher"
 
 	"github.com/mattermost/mattermost-server/v5/model"
@@ -20,8 +22,9 @@ func NewEmptyStep(title, message string) Step {
 
 func (s *emptyStep) PostSlackAttachment(flowHandler string, i int) *model.SlackAttachment {
 	sa := model.SlackAttachment{
-		Title: s.Title,
-		Text:  s.Message,
+		Title:    s.Title,
+		Text:     s.Message,
+		Fallback: fmt.Sprintf("%s: %s", s.Title, s.Message),
 	}
 
 	return &sa

--- a/experimental/flow/steps/freetext_step.go
+++ b/experimental/flow/steps/freetext_step.go
@@ -1,6 +1,8 @@
 package steps
 
 import (
+	"fmt"
+
 	"github.com/mattermost/mattermost-plugin-api/experimental/bot/poster"
 	"github.com/mattermost/mattermost-plugin-api/experimental/freetextfetcher"
 
@@ -43,8 +45,9 @@ func NewFreetextStep(
 
 func (s *freetextStep) PostSlackAttachment(flowHandler string, i int) *model.SlackAttachment {
 	sa := model.SlackAttachment{
-		Title: s.Title,
-		Text:  s.Message,
+		Title:    s.Title,
+		Text:     s.Message,
+		Fallback: fmt.Sprintf("%s: %s", s.Title, s.Message),
 	}
 
 	return &sa

--- a/experimental/flow/steps/simple_step.go
+++ b/experimental/flow/steps/simple_step.go
@@ -2,6 +2,7 @@ package steps
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/mattermost/mattermost-plugin-api/experimental/freetextfetcher"
 
@@ -74,9 +75,10 @@ func (s *simpleStep) PostSlackAttachment(flowHandler string, i int) *model.Slack
 	}
 
 	sa := model.SlackAttachment{
-		Title:   s.Title,
-		Text:    s.Message,
-		Actions: []*model.PostAction{&actionTrue, &actionFalse},
+		Title:    s.Title,
+		Text:     s.Message,
+		Fallback: fmt.Sprintf("%s: %s", s.Title, s.Message),
+		Actions:  []*model.PostAction{&actionTrue, &actionFalse},
 	}
 
 	return &sa
@@ -91,9 +93,10 @@ func (s *simpleStep) ResponseSlackAttachment(rawValue interface{}) *model.SlackA
 	}
 
 	sa := model.SlackAttachment{
-		Title:   s.Title,
-		Text:    message,
-		Actions: []*model.PostAction{},
+		Title:    s.Title,
+		Text:     message,
+		Fallback: fmt.Sprintf("%s: %s", s.Title, message),
+		Actions:  []*model.PostAction{},
 	}
 
 	return &sa

--- a/experimental/freetextfetcher/freetext_fetcher.go
+++ b/experimental/freetextfetcher/freetext_fetcher.go
@@ -146,9 +146,12 @@ func (ftf *freetextFetcher) postConfirmation(userID, message, pluginURL, payload
 		},
 	}
 
+	title := "Confirm input"
+	text := fmt.Sprintf("You have typed `%s`. Is that correct?", message),
 	sa := &model.SlackAttachment{
-		Title:   "Confirm input",
-		Text:    fmt.Sprintf("You have typed `%s`. Is that correct?", message),
+		Title:   title,
+		Text:    text,
+		Fallback: fmt.Sprintf("%s: %s", title, text),
 		Actions: []*model.PostAction{&actionConfirm, &actionRetry, &actionCancel},
 	}
 

--- a/experimental/freetextfetcher/freetext_fetcher.go
+++ b/experimental/freetextfetcher/freetext_fetcher.go
@@ -147,12 +147,12 @@ func (ftf *freetextFetcher) postConfirmation(userID, message, pluginURL, payload
 	}
 
 	title := "Confirm input"
-	text := fmt.Sprintf("You have typed `%s`. Is that correct?", message),
+	text := fmt.Sprintf("You have typed `%s`. Is that correct?", message)
 	sa := &model.SlackAttachment{
-		Title:   title,
-		Text:    text,
+		Title:    title,
+		Text:     text,
 		Fallback: fmt.Sprintf("%s: %s", title, text),
-		Actions: []*model.PostAction{&actionConfirm, &actionRetry, &actionCancel},
+		Actions:  []*model.PostAction{&actionConfirm, &actionRetry, &actionCancel},
 	}
 
 	_, _ = ftf.poster.DMWithAttachments(userID, sa)

--- a/experimental/freetextfetcher/freetext_fetcher.go
+++ b/experimental/freetextfetcher/freetext_fetcher.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mattermost/mattermost-server/v5/plugin"
 )
 
+// FreetextFetcher defines the behavior of free text fetchers
 type FreetextFetcher interface {
 	MessageHasBeenPosted(c *plugin.Context, post *model.Post, api plugin.API, l logger.Logger, botUserID string, pluginURL string)
 	StartFetching(userID string, payload string)
@@ -28,6 +29,7 @@ type freetextFetcher struct {
 	onCancel func(string)
 }
 
+// NewFreetextFetcher creates a new FreetextFetcher
 func NewFreetextFetcher(
 	baseURL string,
 	store FreetextStore,

--- a/experimental/freetextfetcher/freetext_fetcher_manager.go
+++ b/experimental/freetextfetcher/freetext_fetcher_manager.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mattermost/mattermost-server/v5/plugin"
 )
 
+// Manager defines the behavior of the freetext manager
 type Manager interface {
 	MessageHasBeenPosted(c *plugin.Context, post *model.Post, api plugin.API, l logger.Logger, botUserID string, pluginURL string)
 	Clear()
@@ -18,6 +19,7 @@ type manager struct {
 
 var ftfManager manager
 
+// GetManager gets the current manager or creates one if none is created
 func GetManager() Manager {
 	if ftfManager.ftfList == nil {
 		ftfManager.ftfList = []FreetextFetcher{}

--- a/experimental/freetextfetcher/handler.go
+++ b/experimental/freetextfetcher/handler.go
@@ -11,13 +11,19 @@ import (
 )
 
 const (
-	ContextActionKey  = "id"
+	// ContextActionKey defines the key used in the context to store the action ID
+	ContextActionKey = "id"
+	// ContextMessageKey defines the key used in the context to store the message
 	ContextMessageKey = "message"
+	// ContextPayloadKey defines the key used in the context to store the Payload
 	ContextPayloadKey = "payload"
 
+	// ContextNewMessage defines the key used in the context to store the new message
 	ContextNewMessage = "new_message"
+	// ContextNewPayload defines the key used in the context to store the new payload
 	ContextNewPayload = "new_payload"
 
+	// CancelAction codifies the action to cancel the freetext fetching
 	CancelAction = "cancel"
 )
 

--- a/experimental/freetextfetcher/handler.go
+++ b/experimental/freetextfetcher/handler.go
@@ -15,7 +15,7 @@ const (
 	ContextActionKey = "id"
 	// ContextMessageKey defines the key used in the context to store the message
 	ContextMessageKey = "message"
-	// ContextPayloadKey defines the key used in the context to store the Payload
+	// ContextPayloadKey defines the key used in the context to store the payload
 	ContextPayloadKey = "payload"
 
 	// ContextNewMessage defines the key used in the context to store the new message

--- a/experimental/freetextfetcher/store.go
+++ b/experimental/freetextfetcher/store.go
@@ -6,6 +6,7 @@ import (
 	pluginapi "github.com/mattermost/mattermost-plugin-api"
 )
 
+// FreetextStore defines the behavior needed to store all the data for the FreetextFetcher
 type FreetextStore interface {
 	StartFetching(userID, fetcherID, payload string) error
 	StopFetching(userID string) error
@@ -22,6 +23,7 @@ type storeElement struct {
 	payload   string
 }
 
+// NewFreetextStore creates a new store for the FreetextFetcher
 func NewFreetextStore(apiClient pluginapi.Client, keyPrefix string) FreetextStore {
 	return &freetextStore{
 		client:    apiClient,

--- a/experimental/panel/settings/bool_setting.go
+++ b/experimental/panel/settings/bool_setting.go
@@ -12,6 +12,7 @@ type boolSetting struct {
 	store SettingStore
 }
 
+// NewBoolSetting creates a new setting input for boolean values
 func NewBoolSetting(id, title, description, dependsOn string, store SettingStore) Setting {
 	return &boolSetting{
 		baseSetting: baseSetting{
@@ -99,9 +100,10 @@ func (s *boolSetting) GetSlackAttachments(userID, settingHandler string, disable
 
 	text := fmt.Sprintf("%s\n%s", s.description, currentValueMessage)
 	sa := model.SlackAttachment{
-		Title:   title,
-		Text:    text,
-		Actions: actions,
+		Title:    title,
+		Text:     text,
+		Fallback: fmt.Sprintf("%s: %s", title, text),
+		Actions:  actions,
 	}
 
 	return &sa, nil

--- a/experimental/panel/settings/empty_setting.go
+++ b/experimental/panel/settings/empty_setting.go
@@ -10,6 +10,7 @@ type emptySetting struct {
 	baseSetting
 }
 
+// NewEmptySetting creates a new panel value with no setting attached
 func NewEmptySetting(id, title, description string) Setting {
 	return &emptySetting{
 		baseSetting: baseSetting{
@@ -23,8 +24,9 @@ func NewEmptySetting(id, title, description string) Setting {
 func (s *emptySetting) GetSlackAttachments(userID, settingHandler string, disabled bool) (*model.SlackAttachment, error) {
 	title := fmt.Sprintf("Setting: %s", s.title)
 	sa := model.SlackAttachment{
-		Title: title,
-		Text:  s.description,
+		Title:    title,
+		Text:     s.description,
+		Fallback: fmt.Sprintf("%s: %s", title, s.description),
 	}
 
 	return &sa, nil

--- a/experimental/panel/settings/freetext_setting.go
+++ b/experimental/panel/settings/freetext_setting.go
@@ -20,13 +20,13 @@ type freetextSetting struct {
 	ftf           freetextfetcher.FreetextFetcher
 }
 
-//FreetextInfo defines the information needed in the payload for freetext settings
+// FreetextInfo defines the information needed in the payload for freetext settings
 type FreetextInfo struct {
 	SettingID string
 	UserID    string
 }
 
-//NewFreetextSetting creates a new setting input to add any text
+// NewFreetextSetting creates a new setting input to add any text
 func NewFreetextSetting(
 	id,
 	title,

--- a/experimental/panel/settings/freetext_setting.go
+++ b/experimental/panel/settings/freetext_setting.go
@@ -20,11 +20,13 @@ type freetextSetting struct {
 	ftf           freetextfetcher.FreetextFetcher
 }
 
+//FreetextInfo defines the information needed in the payload for freetext settings
 type FreetextInfo struct {
 	SettingID string
 	UserID    string
 }
 
+//NewFreetextSetting creates a new setting input to add any text
 func NewFreetextSetting(
 	id,
 	title,
@@ -112,9 +114,10 @@ func (s *freetextSetting) GetSlackAttachments(userID, settingHandler string, dis
 
 	text := fmt.Sprintf("%s\n%s", s.description, currentValueMessage)
 	sa := model.SlackAttachment{
-		Title:   title,
-		Text:    text,
-		Actions: actions,
+		Title:    title,
+		Text:     text,
+		Fallback: fmt.Sprintf("%s: %s", title, text),
+		Actions:  actions,
 	}
 
 	return &sa, nil

--- a/experimental/panel/settings/option_setting.go
+++ b/experimental/panel/settings/option_setting.go
@@ -13,6 +13,7 @@ type optionSetting struct {
 	store   SettingStore
 }
 
+// NewOptionSetting creates a new setting input to select from a dropdown
 func NewOptionSetting(id, title, description, dependsOn string, options []string, store SettingStore) Setting {
 	return &optionSetting{
 		baseSetting: baseSetting{
@@ -77,9 +78,10 @@ func (s *optionSetting) GetSlackAttachments(userID, settingHandler string, disab
 
 	text := fmt.Sprintf("%s\n%s", s.description, currentValueMessage)
 	sa := model.SlackAttachment{
-		Title:   title,
-		Text:    text,
-		Actions: actions,
+		Title:    title,
+		Text:     text,
+		Fallback: fmt.Sprintf("%s: %s", title, text),
+		Actions:  actions,
 	}
 	return &sa, nil
 }

--- a/experimental/panel/settings/read_only_setting.go
+++ b/experimental/panel/settings/read_only_setting.go
@@ -12,6 +12,7 @@ type readOnlySetting struct {
 	store SettingStore
 }
 
+// NewReadOnlySetting creates a new panel value that only read from the setting
 func NewReadOnlySetting(id, title, description, dependsOn string, store SettingStore) Setting {
 	return &readOnlySetting{
 		baseSetting: baseSetting{
@@ -55,8 +56,9 @@ func (s *readOnlySetting) GetSlackAttachments(userID, settingHandler string, dis
 
 	text := fmt.Sprintf("%s\n%s", s.description, currentValueMessage)
 	sa := model.SlackAttachment{
-		Title: title,
-		Text:  text,
+		Title:    title,
+		Text:     text,
+		Fallback: fmt.Sprintf("%s: %s", title, text),
 	}
 
 	return &sa, nil

--- a/experimental/panel/settings/setting.go
+++ b/experimental/panel/settings/setting.go
@@ -7,15 +7,22 @@ import (
 )
 
 const (
-	ContextIDKey          = "setting_id"
+	//ContextIDKey defines the key used in the context to store the ID
+	ContextIDKey = "setting_id"
+	//ContextButtonValueKey defines the key used in the context to store a button value
 	ContextButtonValueKey = "button_value"
+	//ContextOptionValueKey defines the key used in the context to store a selected option value
 	ContextOptionValueKey = "selected_option"
 
+	//DisabledString defines the string used to show that a setting is disabled
 	DisabledString = "Disabled"
-	TrueString     = "true"
-	FalseString    = "false"
+	//TrueString codify the boolean true into a string
+	TrueString = "true"
+	//FalseString codify the boolean false into a string
+	FalseString = "false"
 )
 
+//Setting defines the behaviour of each element a the panel
 type Setting interface {
 	Set(userID string, value interface{}) error
 	Get(userID string) (interface{}, error)

--- a/experimental/panel/settings/setting.go
+++ b/experimental/panel/settings/setting.go
@@ -7,22 +7,22 @@ import (
 )
 
 const (
-	//ContextIDKey defines the key used in the context to store the ID
+	// ContextIDKey defines the key used in the context to store the ID
 	ContextIDKey = "setting_id"
-	//ContextButtonValueKey defines the key used in the context to store a button value
+	// ContextButtonValueKey defines the key used in the context to store a button value
 	ContextButtonValueKey = "button_value"
-	//ContextOptionValueKey defines the key used in the context to store a selected option value
+	// ContextOptionValueKey defines the key used in the context to store a selected option value
 	ContextOptionValueKey = "selected_option"
 
-	//DisabledString defines the string used to show that a setting is disabled
+	// DisabledString defines the string used to show that a setting is disabled
 	DisabledString = "Disabled"
-	//TrueString codify the boolean true into a string
+	// TrueString codify the boolean true into a string
 	TrueString = "true"
-	//FalseString codify the boolean false into a string
+	// FalseString codify the boolean false into a string
 	FalseString = "false"
 )
 
-//Setting defines the behaviour of each element a the panel
+// Setting defines the behavior of each element a the panel
 type Setting interface {
 	Set(userID string, value interface{}) error
 	Get(userID string) (interface{}, error)

--- a/experimental/panel/settings/store.go
+++ b/experimental/panel/settings/store.go
@@ -1,6 +1,6 @@
 package settings
 
-//SettingStore defines the behaviour needed to set and get settings
+// SettingStore defines the behavior needed to set and get settings
 type SettingStore interface {
 	SetSetting(userID, settingID string, value interface{}) error
 	GetSetting(userID, settingID string) (interface{}, error)

--- a/experimental/panel/settings/store.go
+++ b/experimental/panel/settings/store.go
@@ -1,5 +1,6 @@
 package settings
 
+//SettingStore defines the behaviour needed to set and get settings
 type SettingStore interface {
 	SetSetting(userID, settingID string, value interface{}) error
 	GetSetting(userID, settingID string) (interface{}, error)


### PR DESCRIPTION
#### Summary
Add fallback to slack attachments messages from panel and flow.

#### Ticket Link
None
