### PR TITLE
Add i18n package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,12 @@ require (
 	github.com/gorilla/mux v1.7.4
 	github.com/lib/pq v1.7.0
 	github.com/mattermost/mattermost-server/v5 v5.3.2-0.20200731154015-c5c6a5ce5399
+	github.com/nicksnyder/go-i18n/v2 v2.0.3
 	github.com/pkg/errors v0.9.1
 	github.com/proullon/ramsql v0.0.0-20181213202341-817cee58a244
 	github.com/rudderlabs/analytics-go v3.2.1+incompatible
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+	golang.org/x/text v0.3.3
 )

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ git.apache.org/thrift.git v0.12.0/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqbl
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/Azure/azure-sdk-for-go v26.5.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest v11.5.2+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
+github.com/BurntSushi/toml v0.3.0/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a/go.mod h1:EFZQ978U7x8IRnstaskI3IysnWY5Ao3QgZUKOXlsAdw=
@@ -406,6 +407,8 @@ github.com/nelsam/hel/v2 v2.3.2 h1:tXRsJBqRxj4ISSPCrXhbqF8sT+BXA/UaIvjhYjP5Bhk=
 github.com/nelsam/hel/v2 v2.3.2/go.mod h1:1ZTGfU2PFTOd5mx22i5O0Lc2GY933lQ2wb/ggy+rL3w=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/ngdinhtoan/glide-cleanup v0.2.0/go.mod h1:UQzsmiDOb8YV3nOsCxK/c9zPpCZVNoHScRE3EO9pVMM=
+github.com/nicksnyder/go-i18n/v2 v2.0.3 h1:ks/JkQiOEhhuF6jpNvx+Wih1NIiXzUnZeZVnJuI8R8M=
+github.com/nicksnyder/go-i18n/v2 v2.0.3/go.mod h1:oDab7q8XCYMRlcrBnaY/7B1eOectbvj6B1UPBT+p5jo=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
@@ -632,6 +635,7 @@ golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190506204251-e1dfcc566284/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -717,6 +721,7 @@ golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190316082340-a2f829d7f35f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -758,6 +763,7 @@ golang.org/x/tools v0.0.0-20190327201419-c70d86f8b7cf/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190424220101-1e8e1cfdf96b/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190907020128-2ca718005c18/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=

--- a/i18n/doc.go
+++ b/i18n/doc.go
@@ -1,0 +1,2 @@
+// package i18n provides methods to read translations files and localize strings.
+package i18n

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -1,0 +1,135 @@
+package i18n
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/nicksnyder/go-i18n/v2/i18n"
+	"github.com/pkg/errors"
+	"golang.org/x/text/language"
+)
+
+// PluginAPI is the plugin API interface required to manage translations.
+type PluginAPI interface {
+	GetBundlePath() (string, error)
+	GetConfig() *model.Config
+	GetUser(userID string) (*model.User, *model.AppError)
+	LogWarn(msg string, keyValuePairs ...interface{})
+}
+
+// Message is a string that can be localized.
+//
+// See https://pkg.go.dev/github.com/nicksnyder/go-i18n/v2/i18n?tab=doc#Message for more details.
+type Message = i18n.Message
+
+// LocalizeConfig configures a call to the Localize method on Localizer.
+//
+// See https://pkg.go.dev/github.com/nicksnyder/go-i18n/v2/i18n?tab=doc#LocalizeConfig for more details.
+type LocalizeConfig = i18n.LocalizeConfig
+
+// Localizer provides Localize and MustLocalize methods that return localized messages.
+//
+// See https://pkg.go.dev/github.com/nicksnyder/go-i18n/v2/i18n?tab=doc#Localizer for more details.
+type Localizer = i18n.Localizer
+
+// Bundle stores a set of messages and pluralization rules.
+// Most plugins only need a single bundle
+// that is initialized on activation.
+// It is not goroutine safe to modify the bundle while Localizers
+// are reading from it.
+type Bundle struct {
+	*i18n.Bundle
+	api PluginAPI
+}
+
+// InitBundle loads all localization files  from a given path into a bundle and return this.
+// path is a relative path in the plugin bundle, e.g. assets/i18n.
+// Every file except the ones named active.*.json.
+// The default language is English.
+func InitBundle(api PluginAPI, path string) (*Bundle, error) {
+	bundle := &Bundle{
+		Bundle: i18n.NewBundle(language.English),
+		api:    api,
+	}
+	bundle.RegisterUnmarshalFunc("json", json.Unmarshal)
+
+	bundlePath, err := api.GetBundlePath()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get bundle path")
+	}
+
+	i18nDir := filepath.Join(bundlePath, path)
+
+	files, err := ioutil.ReadDir(i18nDir)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to open i18n directory")
+	}
+
+	for _, file := range files {
+		if !strings.HasPrefix(file.Name(), "active.") {
+			continue
+		}
+
+		if !strings.HasSuffix(file.Name(), ".json") {
+			continue
+		}
+
+		if file.Name() == "active.en.json" {
+			continue
+		}
+
+		_, err = bundle.LoadMessageFile(filepath.Join(i18nDir, file.Name()))
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to load message file %s", file.Name())
+		}
+	}
+
+	return bundle, nil
+}
+
+// GetUserLocalizer returns a localizer that localizes in the users locale.
+func (b *Bundle) GetUserLocalizer(userID string) *i18n.Localizer {
+	user, err := b.api.GetUser(userID)
+	if err != nil {
+		b.api.LogWarn("Failed get user's locale", "error", err.Error())
+		return b.GetServerLocalizer()
+	}
+
+	return i18n.NewLocalizer(b.Bundle, user.Locale)
+}
+
+// GetServerLocalizer returns a localizer that localizes in the default server locale.
+//
+// This is useful for situations where a messages is shown to every user,
+// independent of the users locale.
+func (b *Bundle) GetServerLocalizer() *i18n.Localizer {
+	local := *b.api.GetConfig().LocalizationSettings.DefaultServerLocale
+
+	return i18n.NewLocalizer(b.Bundle, local)
+}
+
+// LocalizeDefaultMessage localizer the provided message.
+// An empty string is returned when the localization fails.
+func (b *Bundle) LocalizeDefaultMessage(l *Localizer, m *Message) string {
+	s, err := l.LocalizeMessage(m)
+	if err != nil {
+		b.api.LogWarn("Failed to localize message", "message ID", m.ID, "error", err.Error())
+		return ""
+	}
+
+	return s
+}
+
+// LocalizeWithConfig localizer the provided localize config.
+// An empty string is returned when the localization fails.
+func (b *Bundle) LocalizeWithConfig(l *Localizer, lc *LocalizeConfig) string {
+	s, err := l.Localize(lc)
+	if err != nil {
+		b.api.LogWarn("Failed to localize with config", "error", err.Error())
+		return ""
+	}
+	return s
+}

--- a/i18n/i18n_test.go
+++ b/i18n/i18n_test.go
@@ -1,0 +1,296 @@
+package i18n_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/text/language"
+
+	"github.com/mattermost/mattermost-plugin-api/i18n"
+)
+
+func ExampleInitBundle() {
+	type Plugin struct {
+		plugin.MattermostPlugin
+
+		b *i18n.Bundle
+	}
+
+	p := Plugin{}
+	b, err := i18n.InitBundle(p.API, filepath.Join("assets", "i18n"))
+	if err != nil {
+		panic(err)
+	}
+
+	p.b = b
+}
+
+func TestInitBundle(t *testing.T) {
+	t.Run("fine", func(t *testing.T) {
+		dir, err := ioutil.TempDir("", "")
+		require.NoError(t, err)
+
+		defer os.RemoveAll(dir)
+
+		// Create assets/i18n dir
+		i18nDir := filepath.Join(dir, "assets", "i18n")
+		err = os.MkdirAll(i18nDir, 0700)
+		require.NoError(t, err)
+
+		file := filepath.Join(i18nDir, "active.de.json")
+		content := []byte("{}")
+		err = ioutil.WriteFile(file, content, 0600)
+		require.NoError(t, err)
+
+		// Add en translation file.
+		// InitBundle should ignore it.
+		file = filepath.Join(i18nDir, "active.en.json")
+		content = []byte("")
+		err = ioutil.WriteFile(file, content, 0600)
+		require.NoError(t, err)
+
+		// Add json junk file
+		file = filepath.Join(i18nDir, "foo.json")
+		content = []byte("")
+		err = ioutil.WriteFile(file, content, 0600)
+		require.NoError(t, err)
+
+		// Add active. junk file
+		file = filepath.Join(i18nDir, "active.foo")
+		content = []byte("")
+		err = ioutil.WriteFile(file, content, 0600)
+		require.NoError(t, err)
+
+		api := &plugintest.API{}
+		api.On("GetBundlePath").Return(dir, nil)
+		defer api.AssertExpectations(t)
+
+		b, err := i18n.InitBundle(api, "assets/i18n")
+		assert.NoError(t, err)
+		assert.NotNil(t, b)
+
+		assert.ElementsMatch(t, []language.Tag{language.English, language.German}, b.LanguageTags())
+	})
+
+	t.Run("fine", func(t *testing.T) {
+		dir, err := ioutil.TempDir("", "")
+		require.NoError(t, err)
+
+		defer os.RemoveAll(dir)
+
+		// Create assets/i18n dir
+		i18nDir := filepath.Join(dir, "assets", "i18n")
+		err = os.MkdirAll(i18nDir, 0700)
+		require.NoError(t, err)
+
+		file := filepath.Join(i18nDir, "active.de.json")
+		content := []byte("{}")
+		err = ioutil.WriteFile(file, content, 0600)
+		require.NoError(t, err)
+
+		// Add translation file with invalid content
+		file = filepath.Join(i18nDir, "active.es.json")
+		content = []byte("foo bar")
+		err = ioutil.WriteFile(file, content, 0600)
+		require.NoError(t, err)
+
+		api := &plugintest.API{}
+		api.On("GetBundlePath").Return(dir, nil)
+		defer api.AssertExpectations(t)
+
+		b, err := i18n.InitBundle(api, "assets/i18n")
+		assert.Error(t, err)
+		assert.Nil(t, b)
+	})
+}
+
+func TestLocalizeDefaultMessage(t *testing.T) {
+	t.Run("fine", func(t *testing.T) {
+		api := &plugintest.API{}
+		defaultServerLocale := "en"
+		api.On("GetConfig").Return(&model.Config{
+			LocalizationSettings: model.LocalizationSettings{
+				DefaultServerLocale: &defaultServerLocale,
+			},
+		})
+		api.On("GetBundlePath").Return(".", nil)
+		defer api.AssertExpectations(t)
+
+		b, err := i18n.InitBundle(api, ".")
+		require.NoError(t, err)
+
+		l := b.GetServerLocalizer()
+		m := &i18n.Message{
+			Other: "test message",
+		}
+
+		assert.Equal(t, m.Other, b.LocalizeDefaultMessage(l, m))
+	})
+
+	t.Run("empty message", func(t *testing.T) {
+		api := &plugintest.API{}
+		defaultServerLocale := "en"
+		api.On("GetConfig").Return(&model.Config{
+			LocalizationSettings: model.LocalizationSettings{
+				DefaultServerLocale: &defaultServerLocale,
+			},
+		})
+		api.On("GetBundlePath").Return(".", nil)
+		api.On("LogWarn", mock.AnythingOfType("string"),
+			mock.AnythingOfType("string"), mock.AnythingOfType("string"),
+			mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return()
+		defer api.AssertExpectations(t)
+
+		b, err := i18n.InitBundle(api, ".")
+		require.NoError(t, err)
+
+		l := b.GetServerLocalizer()
+		m := &i18n.Message{}
+
+		assert.Equal(t, "", b.LocalizeDefaultMessage(l, m))
+	})
+}
+
+func TestLocalizeWithConfig(t *testing.T) {
+	t.Run("fine", func(t *testing.T) {
+		api := &plugintest.API{}
+		defaultServerLocale := "en"
+		api.On("GetConfig").Return(&model.Config{
+			LocalizationSettings: model.LocalizationSettings{
+				DefaultServerLocale: &defaultServerLocale,
+			},
+		})
+		api.On("GetBundlePath").Return(".", nil)
+		defer api.AssertExpectations(t)
+
+		b, err := i18n.InitBundle(api, ".")
+		require.NoError(t, err)
+
+		l := b.GetServerLocalizer()
+		lc := &i18n.LocalizeConfig{
+			DefaultMessage: &i18n.Message{
+				Other: "test messsage",
+			},
+		}
+
+		assert.Equal(t, lc.DefaultMessage.Other, b.LocalizeWithConfig(l, lc))
+	})
+
+	t.Run("empty config", func(t *testing.T) {
+		api := &plugintest.API{}
+		defaultServerLocale := "en"
+		api.On("GetConfig").Return(&model.Config{
+			LocalizationSettings: model.LocalizationSettings{
+				DefaultServerLocale: &defaultServerLocale,
+			},
+		})
+		api.On("GetBundlePath").Return(".", nil)
+		api.On("LogWarn", mock.AnythingOfType("string"),
+			mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return()
+		defer api.AssertExpectations(t)
+
+		b, err := i18n.InitBundle(api, ".")
+		require.NoError(t, err)
+
+		l := b.GetServerLocalizer()
+		lc := &i18n.LocalizeConfig{}
+
+		assert.Equal(t, "", b.LocalizeWithConfig(l, lc))
+	})
+
+	t.Run("empty message", func(t *testing.T) {
+		api := &plugintest.API{}
+		defaultServerLocale := "en"
+		api.On("GetConfig").Return(&model.Config{
+			LocalizationSettings: model.LocalizationSettings{
+				DefaultServerLocale: &defaultServerLocale,
+			},
+		})
+		api.On("GetBundlePath").Return(".", nil)
+		api.On("LogWarn", mock.AnythingOfType("string"),
+			mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return()
+		defer api.AssertExpectations(t)
+
+		b, err := i18n.InitBundle(api, ".")
+		require.NoError(t, err)
+
+		l := b.GetServerLocalizer()
+		lc := &i18n.LocalizeConfig{
+			DefaultMessage: &i18n.Message{},
+		}
+
+		assert.Equal(t, "", b.LocalizeWithConfig(l, lc))
+	})
+}
+func TestGetUserLocalizer(t *testing.T) {
+	t.Run("fine", func(t *testing.T) {
+		api := &plugintest.API{}
+		api.On("GetUser", "userID").Return(&model.User{
+			Locale: "de",
+		}, nil)
+		api.On("GetBundlePath").Return(".", nil)
+		defer api.AssertExpectations(t)
+
+		b, err := i18n.InitBundle(api, ".")
+		require.NoError(t, err)
+
+		l := b.GetUserLocalizer("userID")
+		assert.NotNil(t, l)
+
+		enMessage := &i18n.Message{
+			Other: "a",
+		}
+
+		deMessage := &i18n.Message{
+			Other: "b",
+		}
+
+		err = b.Bundle.AddMessages(language.German, deMessage)
+		require.NoError(t, err)
+
+		assert.Equal(t, deMessage.Other, b.LocalizeDefaultMessage(l, enMessage))
+	})
+
+	t.Run("error", func(t *testing.T) {
+		api := &plugintest.API{}
+		defaultServerLocale := "es"
+		api.On("GetConfig").Return(&model.Config{
+			LocalizationSettings: model.LocalizationSettings{
+				DefaultServerLocale: &defaultServerLocale,
+			},
+		})
+		api.On("GetBundlePath").Return(".", nil)
+		api.On("GetUser", "userID").Return(nil, &model.AppError{})
+		api.On("LogWarn", mock.AnythingOfType("string"),
+			mock.AnythingOfType("string"), mock.AnythingOfType("string"),
+			mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return()
+		defer api.AssertExpectations(t)
+
+		b, err := i18n.InitBundle(api, ".")
+		require.NoError(t, err)
+
+		l := b.GetUserLocalizer("userID")
+		assert.NotNil(t, l)
+
+		enMessage := &i18n.Message{
+			Other: "a",
+		}
+
+		esMessage := &i18n.Message{
+			Other: "b",
+		}
+
+		err = b.Bundle.AddMessages(language.Spanish, esMessage)
+		require.NoError(t, err)
+
+		assert.Equal(t, esMessage.Other, b.LocalizeDefaultMessage(l, enMessage))
+	})
+}


### PR DESCRIPTION
#### Summary
This package provides the needed tools to allow plugins to quickly add support for i18n.

I chose too alias most of they `types` from github.com/nicksnyder/go-i18n/v2 to prevent consumers of this library to import them there self. `Bundle` is composed of `go-i18n.Bundle`, which allows for flexible use. To simplify the API, `Bundle.Bundle` could be made private.



#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-api/issues/14