### PR TITLE
Add GetIconData

### DIFF
--- a/experimental/command/command.go
+++ b/experimental/command/command.go
@@ -1,0 +1,31 @@
+package command
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+// PluginAPI is the plugin API interface required to manage slash commands.
+type PluginAPI interface {
+	GetBundlePath() (string, error)
+}
+
+// GetIconData returns the base64 encoding of a icon for a given path.
+// The data returned may be used for slash command autocomplete.
+func GetIconData(api PluginAPI, iconPath string) (string, error) {
+	bundlePath, err := api.GetBundlePath()
+	if err != nil {
+		return "", errors.Wrap(err, "couldn't get bundle path")
+	}
+
+	icon, err := ioutil.ReadFile(filepath.Join(bundlePath, iconPath))
+	if err != nil {
+		return "", errors.Wrap(err, "failed to open icon")
+	}
+
+	return fmt.Sprintf("data:image/svg+xml;base64,%s", base64.StdEncoding.EncodeToString(icon)), nil
+}


### PR DESCRIPTION
#### Summary
Add a helper method to get the icon data for slash command autocomplete.

#### Ticket Link
Related to https://github.com/mattermost/mattermost-plugin-github/pull/359
