### PR TITLE
allow development mode when checking license

### DIFF
--- a/license.go
+++ b/license.go
@@ -1,0 +1,36 @@
+package pluginapi
+
+import (
+	"github.com/mattermost/mattermost-server/v5/model"
+)
+
+// IsEnterpriseLicensedOrDevelopment returns true when the server is licensed with any Mattermost
+// Enterprise License, or has `EnableDeveloper` and `EnableTesting` configuration settings
+// enabled signalling a non-production, developer mode.
+func IsEnterpriseLicensedOrDevelopment(config *model.Config, license *model.License) bool {
+	if license != nil {
+		return true
+	}
+
+	return isConfiguredForDevelopment(config)
+}
+
+// IsE20LicensedOrDevelopment returns true when the server is licensed with a Mattermost
+// Enterprise E20 License, or has `EnableDeveloper` and `EnableTesting` configuration settings
+// enabled, signalling a non-production, developer mode.
+func IsE20LicensedOrDevelopment(config *model.Config, license *model.License) bool {
+	if license != nil && license.Features != nil && license.Features.FutureFeatures != nil && *license.Features.FutureFeatures {
+		return true
+	}
+
+	return isConfiguredForDevelopment(config)
+}
+
+func isConfiguredForDevelopment(config *model.Config) bool {
+	if config != nil && config.ServiceSettings.EnableTesting != nil && *config.ServiceSettings.EnableTesting && config.ServiceSettings.EnableDeveloper != nil && *config.ServiceSettings.EnableDeveloper {
+		return true
+	}
+
+	return false
+
+}

--- a/license.go
+++ b/license.go
@@ -6,7 +6,7 @@ import (
 
 // IsEnterpriseLicensedOrDevelopment returns true when the server is licensed with any Mattermost
 // Enterprise License, or has `EnableDeveloper` and `EnableTesting` configuration settings
-// enabled signalling a non-production, developer mode.
+// enabled signaling a non-production, developer mode.
 func IsEnterpriseLicensedOrDevelopment(config *model.Config, license *model.License) bool {
 	if license != nil {
 		return true
@@ -17,9 +17,12 @@ func IsEnterpriseLicensedOrDevelopment(config *model.Config, license *model.Lice
 
 // IsE20LicensedOrDevelopment returns true when the server is licensed with a Mattermost
 // Enterprise E20 License, or has `EnableDeveloper` and `EnableTesting` configuration settings
-// enabled, signalling a non-production, developer mode.
+// enabled, signaling a non-production, developer mode.
 func IsE20LicensedOrDevelopment(config *model.Config, license *model.License) bool {
-	if license != nil && license.Features != nil && license.Features.FutureFeatures != nil && *license.Features.FutureFeatures {
+	if license != nil &&
+		license.Features != nil &&
+		license.Features.FutureFeatures != nil &&
+		*license.Features.FutureFeatures {
 		return true
 	}
 
@@ -27,10 +30,13 @@ func IsE20LicensedOrDevelopment(config *model.Config, license *model.License) bo
 }
 
 func isConfiguredForDevelopment(config *model.Config) bool {
-	if config != nil && config.ServiceSettings.EnableTesting != nil && *config.ServiceSettings.EnableTesting && config.ServiceSettings.EnableDeveloper != nil && *config.ServiceSettings.EnableDeveloper {
+	if config != nil &&
+		config.ServiceSettings.EnableTesting != nil &&
+		*config.ServiceSettings.EnableTesting &&
+		config.ServiceSettings.EnableDeveloper != nil &&
+		*config.ServiceSettings.EnableDeveloper {
 		return true
 	}
 
 	return false
-
 }

--- a/license_test.go
+++ b/license_test.go
@@ -1,0 +1,111 @@
+package pluginapi
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsEnterpriseLicensedOrDevelopment(t *testing.T) {
+	t.Run("license, no config", func(t *testing.T) {
+		assert.True(t, IsEnterpriseLicensedOrDevelopment(nil, &model.License{}))
+	})
+
+	t.Run("license, nil config", func(t *testing.T) {
+		assert.True(t, IsEnterpriseLicensedOrDevelopment(
+			&model.Config{ServiceSettings: model.ServiceSettings{EnableDeveloper: nil, EnableTesting: nil}},
+			&model.License{},
+		))
+	})
+
+	t.Run("no license, no config", func(t *testing.T) {
+		assert.False(t, IsEnterpriseLicensedOrDevelopment(nil, nil))
+	})
+
+	t.Run("no license, nil config", func(t *testing.T) {
+		assert.False(t, IsEnterpriseLicensedOrDevelopment(
+			&model.Config{ServiceSettings: model.ServiceSettings{EnableDeveloper: nil, EnableTesting: nil}},
+			nil,
+		))
+	})
+
+	t.Run("no license, only developer mode", func(t *testing.T) {
+		assert.False(t, IsEnterpriseLicensedOrDevelopment(
+			&model.Config{ServiceSettings: model.ServiceSettings{EnableDeveloper: bToP(true), EnableTesting: bToP(false)}},
+			nil,
+		))
+	})
+
+	t.Run("no license, only testing mode", func(t *testing.T) {
+		assert.False(t, IsEnterpriseLicensedOrDevelopment(
+			&model.Config{ServiceSettings: model.ServiceSettings{EnableDeveloper: bToP(false), EnableTesting: bToP(true)}},
+			nil,
+		))
+	})
+
+	t.Run("no license, developer and testing mode", func(t *testing.T) {
+		assert.True(t, IsEnterpriseLicensedOrDevelopment(
+			&model.Config{ServiceSettings: model.ServiceSettings{EnableDeveloper: bToP(true), EnableTesting: bToP(true)}},
+			nil,
+		))
+	})
+}
+
+func TestIsE20LicensedOrDevelopment(t *testing.T) {
+	t.Run("nil license features", func(t *testing.T) {
+		assert.False(t, IsE20LicensedOrDevelopment(nil, &model.License{}))
+	})
+
+	t.Run("nil future features", func(t *testing.T) {
+		assert.False(t, IsE20LicensedOrDevelopment(nil, &model.License{Features: &model.Features{}}))
+	})
+
+	t.Run("disabled future features", func(t *testing.T) {
+		assert.False(t, IsE20LicensedOrDevelopment(nil, &model.License{Features: &model.Features{
+			FutureFeatures: bToP(false),
+		}}))
+	})
+
+	t.Run("enabled future features", func(t *testing.T) {
+		assert.True(t, IsE20LicensedOrDevelopment(nil, &model.License{Features: &model.Features{
+			FutureFeatures: bToP(true),
+		}}))
+	})
+
+	t.Run("no license, no config", func(t *testing.T) {
+		assert.False(t, IsE20LicensedOrDevelopment(nil, nil))
+	})
+
+	t.Run("no license, nil config", func(t *testing.T) {
+		assert.False(t, IsE20LicensedOrDevelopment(
+			&model.Config{ServiceSettings: model.ServiceSettings{EnableDeveloper: nil, EnableTesting: nil}},
+			nil,
+		))
+	})
+
+	t.Run("no license, only developer mode", func(t *testing.T) {
+		assert.False(t, IsE20LicensedOrDevelopment(
+			&model.Config{ServiceSettings: model.ServiceSettings{EnableDeveloper: bToP(true), EnableTesting: bToP(false)}},
+			nil,
+		))
+	})
+
+	t.Run("no license, only testing mode", func(t *testing.T) {
+		assert.False(t, IsE20LicensedOrDevelopment(
+			&model.Config{ServiceSettings: model.ServiceSettings{EnableDeveloper: bToP(false), EnableTesting: bToP(true)}},
+			nil,
+		))
+	})
+
+	t.Run("no license, developer and testing mode", func(t *testing.T) {
+		assert.True(t, IsE20LicensedOrDevelopment(
+			&model.Config{ServiceSettings: model.ServiceSettings{EnableDeveloper: bToP(true), EnableTesting: bToP(true)}},
+			nil,
+		))
+	})
+}
+
+func bToP(b bool) *bool {
+	return &b
+}

--- a/store.go
+++ b/store.go
@@ -92,11 +92,10 @@ func (s *StoreService) initialize() error {
 		return nil
 	}
 
-	if s.api.GetLicense() == nil {
+	config := s.api.GetUnsanitizedConfig()
+	if !IsEnterpriseLicensedOrDevelopment(config, s.api.GetLicense()) {
 		return ErrNoLicense
 	}
-
-	config := s.api.GetUnsanitizedConfig()
 
 	// Set up master db
 	db, err := setupConnection(*config.SqlSettings.DataSource, config.SqlSettings)

--- a/store_test.go
+++ b/store_test.go
@@ -14,12 +14,13 @@ import (
 )
 
 func TestStore(t *testing.T) {
-	t.Run("no license", func(t *testing.T) {
+	t.Run("no license, empty config", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
 		store := pluginapi.NewClient(api).Store
 
 		api.On("GetLicense").Return(nil)
+		api.On("GetUnsanitizedConfig").Return(&model.Config{})
 		db, err := store.GetMasterDB()
 		require.Error(t, err)
 		require.Nil(t, db)


### PR DESCRIPTION
#### Summary
Port the changes from incident response to skip the license check when `EnableDeveloper` and `EnableTesting` is true. These bits are not suitable for use in production, and allow for development testing under the source available license without having to run the enterprise server binary.

Once merged, I'll leverage same in incident response both to simplify the code there and allow our use of the SQL store under the same circumstances.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-28104