### PR TITLE
Use same naming pattern for LogAPI as for plugin API

### DIFF
--- a/experimental/bot/logger/default_logger.go
+++ b/experimental/bot/logger/default_logger.go
@@ -52,23 +52,23 @@ func (l *defaultLogger) Timed() Logger {
 func (l *defaultLogger) Debugf(format string, args ...interface{}) {
 	measure(l.logContext)
 	message := fmt.Sprintf(format, args...)
-	l.logAPI.Debug(message, toKeyValuePairs(l.logContext)...)
+	l.logAPI.LogDebug(message, toKeyValuePairs(l.logContext)...)
 }
 
 func (l *defaultLogger) Errorf(format string, args ...interface{}) {
 	measure(l.logContext)
 	message := fmt.Sprintf(format, args...)
-	l.logAPI.Error(message, toKeyValuePairs(l.logContext)...)
+	l.logAPI.LogError(message, toKeyValuePairs(l.logContext)...)
 }
 
 func (l *defaultLogger) Infof(format string, args ...interface{}) {
 	measure(l.logContext)
 	message := fmt.Sprintf(format, args...)
-	l.logAPI.Info(message, toKeyValuePairs(l.logContext)...)
+	l.logAPI.LogInfo(message, toKeyValuePairs(l.logContext)...)
 }
 
 func (l *defaultLogger) Warnf(format string, args ...interface{}) {
 	measure(l.logContext)
 	message := fmt.Sprintf(format, args...)
-	l.logAPI.Warn(message, toKeyValuePairs(l.logContext)...)
+	l.logAPI.LogWarn(message, toKeyValuePairs(l.logContext)...)
 }

--- a/experimental/common/logapi.go
+++ b/experimental/common/logapi.go
@@ -1,8 +1,8 @@
 package common
 
 type LogAPI interface {
-	Error(message string, keyValuePairs ...interface{})
-	Warn(message string, keyValuePairs ...interface{})
-	Info(message string, keyValuePairs ...interface{})
-	Debug(message string, keyValuePairs ...interface{})
+	LogError(message string, keyValuePairs ...interface{})
+	LogWarn(message string, keyValuePairs ...interface{})
+	LogInfo(message string, keyValuePairs ...interface{})
+	LogDebug(message string, keyValuePairs ...interface{})
 }


### PR DESCRIPTION
#### Summary
This allows plugins to just pass `p.API` to `logger.New`

#### Ticket Link
None
