### PR TITLE
return ErrNotFound when normalizing errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,10 +1,17 @@
 package pluginapi
 
 import (
+	"net/http"
+
 	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/pkg/errors"
 )
 
-// normalizeAppError returns a truly nil error if appErr is nil.
+// ErrNotFound is returned by the plugin API when an object is not found.
+var ErrNotFound = errors.New("not found")
+
+// normalizeAppError returns a truly nil error if appErr is nil as well as normalizing a class
+// of non-nil AppErrors to simplify use within plugins.
 //
 // This doesn't happen automatically when a *model.AppError is cast to an error, since the
 // resulting error interface has a concrete type with a nil value. This leads to the seemingly
@@ -21,6 +28,10 @@ import (
 func normalizeAppErr(appErr *model.AppError) error {
 	if appErr == nil {
 		return nil
+	}
+
+	if appErr.StatusCode == http.StatusNotFound {
+		return ErrNotFound
 	}
 
 	return appErr


### PR DESCRIPTION
#### Summary
Simplify handling of errors by converging on a common `StatusNotFound` error instead of having to discover if the returned `error` is an `*model.AppError` and examine the `StatusCode`.

Example usage:
```go
	user, err := r.pluginAPI.User.GetByUsername(username)
	if errors.Is(err, pluginapi.ErrNotFound) {
		pluginAPI.Log.Info(fmt.Sprintf("Unable to find user @%s", username)))
		return
	} else if err != nil {
		pluginAPI.Log.Warn(fmt.Sprintf("Unable to find user @%s", username)), "err", err)
		return
	}
```