### PR TITLE
MM-31230: Limit the number of idle connections from a plugin

### DIFF
--- a/store.go
+++ b/store.go
@@ -127,8 +127,8 @@ func setupConnection(dataSourceName string, settings model.SqlSettings) (*sql.DB
 		return nil, errors.Wrap(err, "failed to open SQL connection")
 	}
 
-	db.SetMaxOpenConns(15)
-	db.SetMaxIdleConns(2)
+	db.SetMaxOpenConns(2)
+	db.SetMaxIdleConns(0)
 	db.SetConnMaxLifetime(time.Duration(*settings.ConnMaxLifetimeMilliseconds) * time.Millisecond)
 
 	return db, nil


### PR DESCRIPTION
Setting a high number of MaxOpenConns reduce our capabilities to scale in cloud where multiple customers are packed in a single multi-tenant database host. The problem was observed when we noticed an abnormally high amount of connections on our writer nodes in cloud.

Writer nodes had >600 connections open whereas reader nodes had ~200. This was very confusing because our workload is primarily read-heavy, and we have observed the ratio of writer:reader connections to be 1:10. So having more writer conns than readers meant that something was going very wrong somewhere.

@angeloskyratzakos was kind enough to debug this with me and he ran a top idle query on a master node in prod, and we saw than 99% of the idle queries were the incident response plugin running SELECT queries. So looking at the code led to the fact that the IR plugin always runs queries against master, and we have this hardcoded number of open and idle conns.

We have already made a similar change to our config conns, setting open/idle to be 2/0 respectively and observed good improvements. This should be applied here too. I believe plugins should be throttled more than our app servers when it comes to db connections. Primarily because it's an O(n) issue. A user can have n number of plugins and all of them can start opening upto 15 connections to the DB, and then beyond a certain point, the DB just can't keep up.

To start things off, we go with the sensible defaults of 2/0, as we have already done that in prod for config connections. If needed, we can customize this through config also.

https://mattermost.atlassian.net/browse/MM-31239


