### PR TITLE
Export jobMetadata to allow creation of custom NextWaitInterval

### DIFF
--- a/cluster/job_test.go
+++ b/cluster/job_test.go
@@ -97,7 +97,7 @@ func TestMakeWaitForInterval(t *testing.T) {
 				lastFinished = now.Add(testCase.LastFinished)
 			}
 
-			actual := MakeWaitForInterval(testCase.Interval)(now, jobMetadata{
+			actual := MakeWaitForInterval(testCase.Interval)(now, JobMetadata{
 				LastFinished: lastFinished,
 			})
 			assert.Equal(t, testCase.Expected, actual)
@@ -258,7 +258,7 @@ func TestMakeWaitForRoundedInterval(t *testing.T) {
 				lastFinished = testCase.Now.Add(testCase.LastFinished)
 			}
 
-			actual := MakeWaitForRoundedInterval(testCase.Interval)(testCase.Now, jobMetadata{
+			actual := MakeWaitForRoundedInterval(testCase.Interval)(testCase.Now, JobMetadata{
 				LastFinished: lastFinished,
 			})
 			assert.Equal(t, testCase.Expected, actual)


### PR DESCRIPTION
#### Summary

I want to export `jobMetadata` because creating custom `NextWaitInterval` is impossible right now. This is a problem because one must use a custom `NextWaitInterval` to create more advanced scheduling mechanisms using `Schedule`.

#### Ticket Link

N/A