### PR TITLE
Relax store license restrictions

### DIFF
--- a/store.go
+++ b/store.go
@@ -14,9 +14,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ErrNoLicense is returned only when there is no enterprise license set.
-var ErrNoLicense = errors.New("this feature requires a valid enterprise license")
-
 // StoreService exposes the underlying database.
 type StoreService struct {
 	initialized bool
@@ -93,9 +90,6 @@ func (s *StoreService) initialize() error {
 	}
 
 	config := s.api.GetUnsanitizedConfig()
-	if !IsEnterpriseLicensedOrDevelopment(config, s.api.GetLicense()) {
-		return ErrNoLicense
-	}
 
 	// Set up master db
 	db, err := setupConnection(*config.SqlSettings.DataSource, config.SqlSettings)

--- a/store_test.go
+++ b/store_test.go
@@ -14,20 +14,6 @@ import (
 )
 
 func TestStore(t *testing.T) {
-	t.Run("no license, empty config", func(t *testing.T) {
-		api := &plugintest.API{}
-		defer api.AssertExpectations(t)
-		store := pluginapi.NewClient(api).Store
-
-		api.On("GetLicense").Return(nil)
-		api.On("GetUnsanitizedConfig").Return(&model.Config{})
-		db, err := store.GetMasterDB()
-		require.Error(t, err)
-		require.Nil(t, db)
-
-		require.NoError(t, store.Close())
-	})
-
 	t.Run("master db singleton", func(t *testing.T) {
 		db, err := sql.Open("ramsql", "TestStore-master-db")
 		require.NoError(t, err)
@@ -43,7 +29,6 @@ func TestStore(t *testing.T) {
 
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		api.On("GetLicense").Return(&model.License{})
 		api.On("GetUnsanitizedConfig").Return(config)
 
 		store := pluginapi.NewClient(api).Store
@@ -81,7 +66,6 @@ func TestStore(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
 		store := pluginapi.NewClient(api).Store
-		api.On("GetLicense").Return(&model.License{})
 
 		api.On("GetUnsanitizedConfig").Return(config)
 		masterDB, err := store.GetMasterDB()
@@ -117,7 +101,6 @@ func TestStore(t *testing.T) {
 
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		api.On("GetLicense").Return(&model.License{})
 		api.On("GetUnsanitizedConfig").Return(config)
 
 		store := pluginapi.NewClient(api).Store
@@ -164,7 +147,6 @@ func TestStore(t *testing.T) {
 		defer api.AssertExpectations(t)
 		store := pluginapi.NewClient(api).Store
 
-		api.On("GetLicense").Return(&model.License{})
 		api.On("GetUnsanitizedConfig").Return(config)
 		storeMasterDB, err := store.GetMasterDB()
 		require.NoError(t, err)


### PR DESCRIPTION
#### Summary
When we designed the store access in the pluginapi, we made the conscious decision to enforce an E20 license (outside of developer environments).

Unfortunately, this limitation has caused us trouble in Incident Collaboration, where we want to be able to start up the plugin even without a valid E20 license, and selectively enable certain functionality for non-E20 licensed customers. Since the pluginapi enforces E20, we can't get our base functionality off the ground.

After further review, we have decided to simply [lift this restriction altogether](https://community-daily.mattermost.com/core/pl/3akxk61ebjfqmbbh588pn5mrjr). It was always possible to work around anyway.

#### Ticket Link
None.