### PR TITLE
Add version-aware RequestTrialLicense to System

### DIFF
--- a/experimental/bot/mocks/mock_logger.go
+++ b/experimental/bot/mocks/mock_logger.go
@@ -33,6 +33,20 @@ func (m *MockLogger) EXPECT() *MockLoggerMockRecorder {
 	return m.recorder
 }
 
+// Context mocks base method
+func (m *MockLogger) Context() logger.LogContext {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Context")
+	ret0, _ := ret[0].(logger.LogContext)
+	return ret0
+}
+
+// Context indicates an expected call of Context
+func (mr *MockLoggerMockRecorder) Context() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockLogger)(nil).Context))
+}
+
 // Debugf mocks base method
 func (m *MockLogger) Debugf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
@@ -127,4 +141,18 @@ func (m *MockLogger) With(arg0 logger.LogContext) logger.Logger {
 func (mr *MockLoggerMockRecorder) With(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "With", reflect.TypeOf((*MockLogger)(nil).With), arg0)
+}
+
+// WithError mocks base method
+func (m *MockLogger) WithError(arg0 error) logger.Logger {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WithError", arg0)
+	ret0, _ := ret[0].(logger.Logger)
+	return ret0
+}
+
+// WithError indicates an expected call of WithError
+func (mr *MockLoggerMockRecorder) WithError(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithError", reflect.TypeOf((*MockLogger)(nil).WithError), arg0)
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang/mock v1.4.4
 	github.com/gorilla/mux v1.8.0
 	github.com/lib/pq v1.10.0
-	github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210430151419-e43861a6358f
+	github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210514083559-0bf7aed02e2c
 	github.com/nicksnyder/go-i18n/v2 v2.0.3
 	github.com/pkg/errors v0.9.1
 	github.com/proullon/ramsql v0.0.0-20181213202341-817cee58a244

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang/mock v1.4.4
 	github.com/gorilla/mux v1.8.0
 	github.com/lib/pq v1.10.0
-	github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210412170128-2de65cfb1160
+	github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210430151419-e43861a6358f
 	github.com/nicksnyder/go-i18n/v2 v2.0.3
 	github.com/pkg/errors v0.9.1
 	github.com/proullon/ramsql v0.0.0-20181213202341-817cee58a244

--- a/go.sum
+++ b/go.sum
@@ -589,8 +589,8 @@ github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d h1:/RJ/UV7M5c7L2TQ
 github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d/go.mod h1:HLbgMEI5K131jpxGazJ97AxfPDt31osq36YS1oxFQPQ=
 github.com/mattermost/logr v1.0.13 h1:6F/fM3csvH6Oy5sUpJuW7YyZSzZZAhJm5VcgKMxA2P8=
 github.com/mattermost/logr v1.0.13/go.mod h1:Mt4DPu1NXMe6JxPdwCC0XBoxXmN9eXOIRPoZarU2PXs=
-github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210430151419-e43861a6358f h1:qACDcE5HiKLz6BRll92I/Pl6IWZ9B6TjEumc9u/fOGQ=
-github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210430151419-e43861a6358f/go.mod h1:6CqGEG0Vnhrl23h8LB+lcOIT8KIUhzbJ7qhXlV7Ek9U=
+github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210514083559-0bf7aed02e2c h1:MdnrC+oQ7S1RehNGqYavOZyZd2ig1Ml1ggBQOT1rFK4=
+github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210514083559-0bf7aed02e2c/go.mod h1:6CqGEG0Vnhrl23h8LB+lcOIT8KIUhzbJ7qhXlV7Ek9U=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=

--- a/go.sum
+++ b/go.sum
@@ -583,14 +583,14 @@ github.com/markbates/pkger v0.15.1/go.mod h1:0JoVlrol20BSywW79rN3kdFFsE5xYM+rSCQ
 github.com/marstr/guid v0.0.0-20170427235115-8bdf7d1a087c/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
 github.com/mattermost/go-i18n v1.11.0 h1:1hLKqn/ZvhZ80OekjVPGYcCrBfMz+YxNNgqS+beL7zE=
 github.com/mattermost/go-i18n v1.11.0/go.mod h1:RyS7FDNQlzF1PsjbJWHRI35exqaKGSO9qD4iv8QjE34=
-github.com/mattermost/gorp v1.6.2-0.20200624165429-2595d5e54111/go.mod h1:QCQ3U0M9T/BlAdjKFJo0I1oe/YAgbyjNdhU8bpOLafk=
+github.com/mattermost/gorp v1.6.2-0.20210419141818-0904a6a388d3/go.mod h1:QCQ3U0M9T/BlAdjKFJo0I1oe/YAgbyjNdhU8bpOLafk=
 github.com/mattermost/gosaml2 v0.3.3/go.mod h1:Z429EIOiEi9kbq6yHoApfzlcXpa6dzRDc6pO+Vy2Ksk=
 github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d h1:/RJ/UV7M5c7L2TQ0KNm4yZxxFvC1nvRz/gY/Daa35aI=
 github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d/go.mod h1:HLbgMEI5K131jpxGazJ97AxfPDt31osq36YS1oxFQPQ=
 github.com/mattermost/logr v1.0.13 h1:6F/fM3csvH6Oy5sUpJuW7YyZSzZZAhJm5VcgKMxA2P8=
 github.com/mattermost/logr v1.0.13/go.mod h1:Mt4DPu1NXMe6JxPdwCC0XBoxXmN9eXOIRPoZarU2PXs=
-github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210412170128-2de65cfb1160 h1:SC0EM0QGk8rga2+yEwAO0Z2AV61Y3RHEOEbTKvAlWdQ=
-github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210412170128-2de65cfb1160/go.mod h1:xn2/aF7VrTae7Ad6mVmHPA2T3Si1cl3K67xgp9O/Zag=
+github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210430151419-e43861a6358f h1:qACDcE5HiKLz6BRll92I/Pl6IWZ9B6TjEumc9u/fOGQ=
+github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210430151419-e43861a6358f/go.mod h1:6CqGEG0Vnhrl23h8LB+lcOIT8KIUhzbJ7qhXlV7Ek9U=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=

--- a/license.go
+++ b/license.go
@@ -15,6 +15,20 @@ func IsEnterpriseLicensedOrDevelopment(config *model.Config, license *model.Lice
 	return IsConfiguredForDevelopment(config)
 }
 
+// IsE10LicensedOrDevelopment returns true when the server is licensed with a Mattermost
+// Enterprise E10 License, or has `EnableDeveloper` and `EnableTesting` configuration settings
+// enabled, signaling a non-production, developer mode.
+func IsE10LicensedOrDevelopment(config *model.Config, license *model.License) bool {
+	if license != nil &&
+		license.Features != nil &&
+		license.Features.LDAP != nil &&
+		*license.Features.LDAP {
+		return true
+	}
+
+	return IsConfiguredForDevelopment(config)
+}
+
 // IsE20LicensedOrDevelopment returns true when the server is licensed with a Mattermost
 // Enterprise E20 License, or has `EnableDeveloper` and `EnableTesting` configuration settings
 // enabled, signaling a non-production, developer mode.

--- a/license_test.go
+++ b/license_test.go
@@ -106,6 +106,60 @@ func TestIsE20LicensedOrDevelopment(t *testing.T) {
 	})
 }
 
+func TestIsE10LicensedOrDevelopment(t *testing.T) {
+	t.Run("nil license features", func(t *testing.T) {
+		assert.False(t, IsE10LicensedOrDevelopment(nil, &model.License{}))
+	})
+
+	t.Run("nil future features", func(t *testing.T) {
+		assert.False(t, IsE10LicensedOrDevelopment(nil, &model.License{Features: &model.Features{}}))
+	})
+
+	t.Run("disabled LDAP", func(t *testing.T) {
+		assert.False(t, IsE10LicensedOrDevelopment(nil, &model.License{Features: &model.Features{
+			LDAP: bToP(false),
+		}}))
+	})
+
+	t.Run("enabled LDAP", func(t *testing.T) {
+		assert.True(t, IsE10LicensedOrDevelopment(nil, &model.License{Features: &model.Features{
+			LDAP: bToP(true),
+		}}))
+	})
+
+	t.Run("no license, no config", func(t *testing.T) {
+		assert.False(t, IsE10LicensedOrDevelopment(nil, nil))
+	})
+
+	t.Run("no license, nil config", func(t *testing.T) {
+		assert.False(t, IsE10LicensedOrDevelopment(
+			&model.Config{ServiceSettings: model.ServiceSettings{EnableDeveloper: nil, EnableTesting: nil}},
+			nil,
+		))
+	})
+
+	t.Run("no license, only developer mode", func(t *testing.T) {
+		assert.False(t, IsE10LicensedOrDevelopment(
+			&model.Config{ServiceSettings: model.ServiceSettings{EnableDeveloper: bToP(true), EnableTesting: bToP(false)}},
+			nil,
+		))
+	})
+
+	t.Run("no license, only testing mode", func(t *testing.T) {
+		assert.False(t, IsE10LicensedOrDevelopment(
+			&model.Config{ServiceSettings: model.ServiceSettings{EnableDeveloper: bToP(false), EnableTesting: bToP(true)}},
+			nil,
+		))
+	})
+
+	t.Run("no license, developer and testing mode", func(t *testing.T) {
+		assert.True(t, IsE20LicensedOrDevelopment(
+			&model.Config{ServiceSettings: model.ServiceSettings{EnableDeveloper: bToP(true), EnableTesting: bToP(true)}},
+			nil,
+		))
+	})
+}
+
 func bToP(b bool) *bool {
 	return &b
 }

--- a/system.go
+++ b/system.go
@@ -74,7 +74,7 @@ func (s *SystemService) GetDiagnosticID() string {
 // RequestTrialLicense requests a trial license and installs it in the server.
 // If the server version is lower than 5.36.0, an error is returned.
 //
-// Minimum server version: 5.4
+// Minimum server version: 5.36
 func (s *SystemService) RequestTrialLicense(requesterID string, users int, termsAccepted, receiveEmailsAccepted bool) error {
 	currentVersion := semver.MustParse(s.api.GetServerVersion())
 	requiredVersion := semver.MustParse("5.36.0")

--- a/system.go
+++ b/system.go
@@ -3,6 +3,7 @@ package pluginapi
 import (
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/plugin"
 	"github.com/pkg/errors"
@@ -68,4 +69,20 @@ func (s *SystemService) GetSystemInstallDate() (time.Time, error) {
 func (s *SystemService) GetDiagnosticID() string {
 	// TODO: Consider deprecating/rewriting in favor of just using GetUnsanitizedConfig().
 	return s.api.GetDiagnosticId()
+}
+
+// RequestTrialLicense requests a trial license and installs it in the server.
+// If the server version is lower than 5.36.0, an error is returned.
+//
+// Minimum server version: 5.4
+func (s *SystemService) RequestTrialLicense(requesterID string, users int, termsAccepted, receiveEmailsAccepted bool) error {
+	currentVersion := semver.MustParse(s.api.GetServerVersion())
+	requiredVersion := semver.MustParse("5.36.0")
+
+	if currentVersion.LT(requiredVersion) {
+		return errors.Errorf("current server version is lower than 5.36")
+	}
+
+	err := s.api.RequestTrialLicense(requesterID, users, termsAccepted, receiveEmailsAccepted)
+	return normalizeAppErr(err)
 }

--- a/system_test.go
+++ b/system_test.go
@@ -76,3 +76,30 @@ func TestGetManifest(t *testing.T) {
 		require.Nil(t, m)
 	})
 }
+
+func TestRequestTrialLicense(t *testing.T) {
+	t.Run("Server version incompatible", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+		client := pluginapi.NewClient(api)
+
+		api.On("GetServerVersion").Return("5.35.0")
+		err := client.System.RequestTrialLicense("requesterID", 10, true, true)
+
+		require.Error(t, err)
+		require.Equal(t, "current server version is lower than 5.36", err.Error())
+	})
+
+	t.Run("Server version compatible", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+		client := pluginapi.NewClient(api)
+
+		api.On("GetServerVersion").Return("5.36.0")
+		api.On("RequestTrialLicense", "requesterID", 10, true, true).Return(nil)
+
+		err := client.System.RequestTrialLicense("requesterID", 10, true, true)
+
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
#### Summary
Adds a RequestTrialLicense that gracefully degrades in servers with a version lower to 5.36.0

This needs to wait for https://github.com/mattermost/mattermost-server/pull/17551 to be merged.

#### Ticket Link
Needed by https://mattermost.atlassian.net/browse/MM-34665