### PR TITLE
Add E10 license check

### DIFF
--- a/license.go
+++ b/license.go
@@ -15,6 +15,20 @@ func IsEnterpriseLicensedOrDevelopment(config *model.Config, license *model.Lice
 	return IsConfiguredForDevelopment(config)
 }
 
+// IsE10LicensedOrDevelopment returns true when the server is licensed with a Mattermost
+// Enterprise E10 License, or has `EnableDeveloper` and `EnableTesting` configuration settings
+// enabled, signaling a non-production, developer mode.
+func IsE10LicensedOrDevelopment(config *model.Config, license *model.License) bool {
+	if license != nil &&
+		license.Features != nil &&
+		license.Features.LDAP != nil &&
+		*license.Features.LDAP {
+		return true
+	}
+
+	return IsConfiguredForDevelopment(config)
+}
+
 // IsE20LicensedOrDevelopment returns true when the server is licensed with a Mattermost
 // Enterprise E20 License, or has `EnableDeveloper` and `EnableTesting` configuration settings
 // enabled, signaling a non-production, developer mode.

--- a/license_test.go
+++ b/license_test.go
@@ -106,6 +106,60 @@ func TestIsE20LicensedOrDevelopment(t *testing.T) {
 	})
 }
 
+func TestIsE10LicensedOrDevelopment(t *testing.T) {
+	t.Run("nil license features", func(t *testing.T) {
+		assert.False(t, IsE10LicensedOrDevelopment(nil, &model.License{}))
+	})
+
+	t.Run("nil future features", func(t *testing.T) {
+		assert.False(t, IsE10LicensedOrDevelopment(nil, &model.License{Features: &model.Features{}}))
+	})
+
+	t.Run("disabled LDAP", func(t *testing.T) {
+		assert.False(t, IsE10LicensedOrDevelopment(nil, &model.License{Features: &model.Features{
+			LDAP: bToP(false),
+		}}))
+	})
+
+	t.Run("enabled LDAP", func(t *testing.T) {
+		assert.True(t, IsE10LicensedOrDevelopment(nil, &model.License{Features: &model.Features{
+			LDAP: bToP(true),
+		}}))
+	})
+
+	t.Run("no license, no config", func(t *testing.T) {
+		assert.False(t, IsE10LicensedOrDevelopment(nil, nil))
+	})
+
+	t.Run("no license, nil config", func(t *testing.T) {
+		assert.False(t, IsE10LicensedOrDevelopment(
+			&model.Config{ServiceSettings: model.ServiceSettings{EnableDeveloper: nil, EnableTesting: nil}},
+			nil,
+		))
+	})
+
+	t.Run("no license, only developer mode", func(t *testing.T) {
+		assert.False(t, IsE10LicensedOrDevelopment(
+			&model.Config{ServiceSettings: model.ServiceSettings{EnableDeveloper: bToP(true), EnableTesting: bToP(false)}},
+			nil,
+		))
+	})
+
+	t.Run("no license, only testing mode", func(t *testing.T) {
+		assert.False(t, IsE10LicensedOrDevelopment(
+			&model.Config{ServiceSettings: model.ServiceSettings{EnableDeveloper: bToP(false), EnableTesting: bToP(true)}},
+			nil,
+		))
+	})
+
+	t.Run("no license, developer and testing mode", func(t *testing.T) {
+		assert.True(t, IsE20LicensedOrDevelopment(
+			&model.Config{ServiceSettings: model.ServiceSettings{EnableDeveloper: bToP(true), EnableTesting: bToP(true)}},
+			nil,
+		))
+	})
+}
+
 func bToP(b bool) *bool {
 	return &b
 }


### PR DESCRIPTION
#### Summary
Add a function to check whether the server is E10-licensed, using the LDAP feature as the flag.

#### Ticket Link
--