### PR TITLE
MM-36167: Use SKU short name with feature check as fallback

### DIFF
--- a/license.go
+++ b/license.go
@@ -4,6 +4,13 @@ import (
 	"github.com/mattermost/mattermost-server/v5/model"
 )
 
+const (
+	e10          = "E10"
+	e20          = "E20"
+	professional = "professional"
+	enterprise   = "enterprise"
+)
+
 // IsEnterpriseLicensedOrDevelopment returns true when the server is licensed with any Mattermost
 // Enterprise License, or has `EnableDeveloper` and `EnableTesting` configuration settings
 // enabled signaling a non-production, developer mode.
@@ -15,29 +22,62 @@ func IsEnterpriseLicensedOrDevelopment(config *model.Config, license *model.Lice
 	return IsConfiguredForDevelopment(config)
 }
 
-// IsE10LicensedOrDevelopment returns true when the server is licensed with a Mattermost
-// Enterprise E10 License, or has `EnableDeveloper` and `EnableTesting` configuration settings
-// enabled, signaling a non-production, developer mode.
+// isValidSkuShortName returns whether the SKU short name is one of the known strings;
+// namely: E10 or professional, or E20 or enterprise
+func isValidSkuShortName(license *model.License) bool {
+	if license == nil {
+		return false
+	}
+
+	switch license.SkuShortName {
+	case e10, e20, professional, enterprise:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsE10LicensedOrDevelopment returns true when the server is at least licensed with a legacy Mattermost
+// Enterprise E10 License or a Mattermost Professional License, or has `EnableDeveloper` and
+// `EnableTesting` configuration settings enabled, signaling a non-production, developer mode.
 func IsE10LicensedOrDevelopment(config *model.Config, license *model.License) bool {
 	if license != nil &&
-		license.Features != nil &&
-		license.Features.LDAP != nil &&
-		*license.Features.LDAP {
+		(license.SkuShortName == e10 || license.SkuShortName == professional ||
+			license.SkuShortName == e20 || license.SkuShortName == enterprise) {
 		return true
+	}
+
+	if !isValidSkuShortName(license) {
+		// As a fallback for licenses whose SKU short name is unknown, make a best effort to try
+		// and use the presence of a known E10/Professional feature as a check to determine licensing.
+		if license != nil &&
+			license.Features != nil &&
+			license.Features.LDAP != nil &&
+			*license.Features.LDAP {
+			return true
+		}
 	}
 
 	return IsConfiguredForDevelopment(config)
 }
 
-// IsE20LicensedOrDevelopment returns true when the server is licensed with a Mattermost
-// Enterprise E20 License, or has `EnableDeveloper` and `EnableTesting` configuration settings
-// enabled, signaling a non-production, developer mode.
+// IsE20LicensedOrDevelopment returns true when the server is licensed with a legacy Mattermost
+// Enterprise E20 License or a Mattermost Enterprise License, or has `EnableDeveloper` and
+// `EnableTesting` configuration settings enabled, signaling a non-production, developer mode.
 func IsE20LicensedOrDevelopment(config *model.Config, license *model.License) bool {
-	if license != nil &&
-		license.Features != nil &&
-		license.Features.FutureFeatures != nil &&
-		*license.Features.FutureFeatures {
+	if license != nil && (license.SkuShortName == e20 || license.SkuShortName == enterprise) {
 		return true
+	}
+
+	if !isValidSkuShortName(license) {
+		// As a fallback for licenses whose SKU short name is unknown, make a best effort to try
+		// and use the presence of a known E20/Enterprise feature as a check to determine licensing.
+		if license != nil &&
+			license.Features != nil &&
+			license.Features.FutureFeatures != nil &&
+			*license.Features.FutureFeatures {
+			return true
+		}
 	}
 
 	return IsConfiguredForDevelopment(config)


### PR DESCRIPTION
#### Summary
This PR updates the  license checks to use the proposed new way of detecting them. The details are [in this document](https://docs.google.com/document/d/1PhlIiGXbAl-sTRFXLRT5R71eSzUTA0HXAVNXPu1aAVU/edit), but the gist of it is that we are now using the SKU shortname instead of specific features. As the old names will be in use for at least two more years, we need to check for both the old ones (E10, E20) and the new ones (professional, enterprise). The possible names are the keys in this map: https://github.com/mattermost/customer-web-server/blob/master/licenses/licenses.go#L98

As a fallback for legacy licenses with potentially unknown SKU shortnames, we default to the old way of looking at a specific feature that we know is in the license we are checking. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36167

