### PR TITLE
MM-32421: Extend channel sidebar category APIs for PluginAPI

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -217,6 +217,36 @@ func (c *ChannelService) UpdateChannelMemberNotifications(channelID, userID stri
 	return channelMember, normalizeAppErr(appErr)
 }
 
+// TODO: should we create a SidebarService?
+
+// CreateSidebarCategory creates a new sidebar category for a set of channels.
+//
+// Minimum server version: 5.37
+func (c *ChannelService) CreateSidebarCategory(userID, teamID string, newCategory *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, error) {
+	category, appErr := c.api.CreateChannelSidebarCategory(userID, teamID, newCategory)
+
+	return category, normalizeAppErr(appErr)
+}
+
+// GetSidebarCategories returns sidebar categories.
+//
+// Minimum server version: 5.37
+func (c *ChannelService) GetSidebarCategories(userID, teamID string) (*model.OrderedSidebarCategories, error) {
+	categories, appErr := c.api.GetChannelSidebarCategories(userID, teamID)
+
+	return categories, normalizeAppErr(appErr)
+}
+
+// UpdateSidebarCategories updates the channel sidebar categories.
+//
+// Minimum server version: 5.37
+func (c *ChannelService) UpdateSidebarCategories(userID, teamID string, categories []*model.SidebarCategoryWithChannels) ([]*model.SidebarCategoryWithChannels, error) {
+	updatedCategory, appErr := c.api.UpdateChannelSidebarCategories(userID, teamID, categories)
+
+	return updatedCategory, normalizeAppErr(appErr)
+}
+
+
 func (c *ChannelService) waitForChannelCreation(channelID string) error {
 	if len(c.api.GetConfig().SqlSettings.DataSourceReplicas) == 0 {
 		return nil

--- a/channel.go
+++ b/channel.go
@@ -221,10 +221,14 @@ func (c *ChannelService) UpdateChannelMemberNotifications(channelID, userID stri
 //
 // Minimum server version: 5.37
 func (c *ChannelService) CreateSidebarCategory(
-	userID, teamID string, newCategory *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, error) {
+	userID, teamID string, newCategory *model.SidebarCategoryWithChannels) error {
 	category, appErr := c.api.CreateChannelSidebarCategory(userID, teamID, newCategory)
+	if appErr != nil {
+		return normalizeAppErr(appErr)
+	}
+	*newCategory = *category
 
-	return category, normalizeAppErr(appErr)
+	return nil
 }
 
 // GetSidebarCategories returns sidebar categories.
@@ -240,10 +244,14 @@ func (c *ChannelService) GetSidebarCategories(userID, teamID string) (*model.Ord
 //
 // Minimum server version: 5.37
 func (c *ChannelService) UpdateSidebarCategories(
-	userID, teamID string, categories []*model.SidebarCategoryWithChannels) ([]*model.SidebarCategoryWithChannels, error) {
-	updatedCategory, appErr := c.api.UpdateChannelSidebarCategories(userID, teamID, categories)
+	userID, teamID string, categories *[]*model.SidebarCategoryWithChannels) error {
+	updatedCategories, appErr := c.api.UpdateChannelSidebarCategories(userID, teamID, *categories)
+	if appErr != nil {
+		return normalizeAppErr(appErr)
+	}
+	*categories = updatedCategories
 
-	return updatedCategory, normalizeAppErr(appErr)
+	return nil
 }
 
 func (c *ChannelService) waitForChannelCreation(channelID string) error {

--- a/channel.go
+++ b/channel.go
@@ -244,12 +244,12 @@ func (c *ChannelService) GetSidebarCategories(userID, teamID string) (*model.Ord
 //
 // Minimum server version: 5.37
 func (c *ChannelService) UpdateSidebarCategories(
-	userID, teamID string, categories *[]*model.SidebarCategoryWithChannels) error {
-	updatedCategories, appErr := c.api.UpdateChannelSidebarCategories(userID, teamID, *categories)
+	userID, teamID string, categories []*model.SidebarCategoryWithChannels) error {
+	updatedCategories, appErr := c.api.UpdateChannelSidebarCategories(userID, teamID, categories)
 	if appErr != nil {
 		return normalizeAppErr(appErr)
 	}
-	*categories = updatedCategories
+	copy(categories, updatedCategories)
 
 	return nil
 }

--- a/channel.go
+++ b/channel.go
@@ -217,12 +217,11 @@ func (c *ChannelService) UpdateChannelMemberNotifications(channelID, userID stri
 	return channelMember, normalizeAppErr(appErr)
 }
 
-// TODO: should we create a SidebarService?
-
 // CreateSidebarCategory creates a new sidebar category for a set of channels.
 //
 // Minimum server version: 5.37
-func (c *ChannelService) CreateSidebarCategory(userID, teamID string, newCategory *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, error) {
+func (c *ChannelService) CreateSidebarCategory(
+	userID, teamID string, newCategory *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, error) {
 	category, appErr := c.api.CreateChannelSidebarCategory(userID, teamID, newCategory)
 
 	return category, normalizeAppErr(appErr)
@@ -240,12 +239,12 @@ func (c *ChannelService) GetSidebarCategories(userID, teamID string) (*model.Ord
 // UpdateSidebarCategories updates the channel sidebar categories.
 //
 // Minimum server version: 5.37
-func (c *ChannelService) UpdateSidebarCategories(userID, teamID string, categories []*model.SidebarCategoryWithChannels) ([]*model.SidebarCategoryWithChannels, error) {
+func (c *ChannelService) UpdateSidebarCategories(
+	userID, teamID string, categories []*model.SidebarCategoryWithChannels) ([]*model.SidebarCategoryWithChannels, error) {
 	updatedCategory, appErr := c.api.UpdateChannelSidebarCategories(userID, teamID, categories)
 
 	return updatedCategory, normalizeAppErr(appErr)
 }
-
 
 func (c *ChannelService) waitForChannelCreation(channelID string) error {
 	if len(c.api.GetConfig().SqlSettings.DataSourceReplicas) == 0 {

--- a/channel_test.go
+++ b/channel_test.go
@@ -245,9 +245,9 @@ func TestCreateSidebarCategory(t *testing.T) {
 		defer api.AssertExpectations(t)
 		client := pluginapi.NewClient(api, &plugintest.Driver{})
 
-		inputCategory := model.SidebarCategoryWithChannels{}
+		category := model.SidebarCategoryWithChannels{}
 
-		api.On("CreateChannelSidebarCategory", "user_id", "team_id", &inputCategory).
+		api.On("CreateChannelSidebarCategory", "user_id", "team_id", &category).
 			Return(&model.SidebarCategoryWithChannels{
 				SidebarCategory: model.SidebarCategory{
 					Id:     "id",
@@ -257,14 +257,14 @@ func TestCreateSidebarCategory(t *testing.T) {
 				Channels: []string{"channelA", "channelB"}},
 				nil)
 
-		category, err := client.Channel.CreateSidebarCategory("user_id", "team_id", &inputCategory)
+		err := client.Channel.CreateSidebarCategory("user_id", "team_id", &category)
 
 		require.NoError(t, err)
 		require.Equal(t,
 			model.SidebarCategoryWithChannels{
 				SidebarCategory: model.SidebarCategory{Id: "id", UserId: "user_id", TeamId: "team_id"},
 				Channels:        []string{"channelA", "channelB"}},
-			*category)
+			category)
 	})
 
 	t.Run("failure", func(t *testing.T) {
@@ -278,7 +278,7 @@ func TestCreateSidebarCategory(t *testing.T) {
 		api.On("CreateChannelSidebarCategory", "user_id", "team_id", &inputCategory).
 			Return(&model.SidebarCategoryWithChannels{}, appErr)
 
-		_, err := client.Channel.CreateSidebarCategory("user_id", "team_id", &inputCategory)
+		err := client.Channel.CreateSidebarCategory("user_id", "team_id", &inputCategory)
 
 		require.Equal(t, appErr, err)
 	})
@@ -328,29 +328,28 @@ func TestUpdateSidebarCategories(t *testing.T) {
 		api := &plugintest.API{}
 		client := pluginapi.NewClient(api, &plugintest.Driver{})
 
-		inputCategories := []*model.SidebarCategoryWithChannels{
+		categories := []*model.SidebarCategoryWithChannels{
 			{
 				SidebarCategory: model.SidebarCategory{},
 				Channels:        nil,
 			},
 		}
-
-		api.On("UpdateChannelSidebarCategories", "user_id", "team_id", inputCategories).Return([]*model.SidebarCategoryWithChannels{
+		updatedCategories := []*model.SidebarCategoryWithChannels{
 			{
-				SidebarCategory: model.SidebarCategory{},
-				Channels:        []string{"channelA", "channelB"},
-			},
-		}, nil)
+				SidebarCategory: model.SidebarCategory{
+					Id:     "id",
+					UserId: "user_id",
+					TeamId: "team_id",
+				},
+				Channels: []string{"channelA", "channelB"},
+			}}
 
-		updatedCategory, err := client.Channel.UpdateSidebarCategories("user_id", "team_id", inputCategories)
+		api.On("UpdateChannelSidebarCategories", "user_id", "team_id", categories).Return(updatedCategories, nil)
+
+		err := client.Channel.UpdateSidebarCategories("user_id", "team_id", &categories)
 
 		require.NoError(t, err)
-		require.Equal(t, []*model.SidebarCategoryWithChannels{
-			{
-				SidebarCategory: model.SidebarCategory{},
-				Channels:        []string{"channelA", "channelB"},
-			},
-		}, updatedCategory)
+		require.EqualValues(t, updatedCategories, categories)
 	})
 
 	t.Run("failure", func(t *testing.T) {
@@ -367,7 +366,7 @@ func TestUpdateSidebarCategories(t *testing.T) {
 
 		api.On("UpdateChannelSidebarCategories", "user_id", "team_id", inputCategories).Return(nil, appErr)
 
-		_, err := client.Channel.UpdateSidebarCategories("user_id", "team_id", inputCategories)
+		err := client.Channel.UpdateSidebarCategories("user_id", "team_id", &inputCategories)
 
 		require.Equal(t, appErr, err)
 	})

--- a/channel_test.go
+++ b/channel_test.go
@@ -346,7 +346,7 @@ func TestUpdateSidebarCategories(t *testing.T) {
 
 		api.On("UpdateChannelSidebarCategories", "user_id", "team_id", categories).Return(updatedCategories, nil)
 
-		err := client.Channel.UpdateSidebarCategories("user_id", "team_id", &categories)
+		err := client.Channel.UpdateSidebarCategories("user_id", "team_id", categories)
 
 		require.NoError(t, err)
 		require.EqualValues(t, updatedCategories, categories)
@@ -366,7 +366,7 @@ func TestUpdateSidebarCategories(t *testing.T) {
 
 		api.On("UpdateChannelSidebarCategories", "user_id", "team_id", inputCategories).Return(nil, appErr)
 
-		err := client.Channel.UpdateSidebarCategories("user_id", "team_id", &inputCategories)
+		err := client.Channel.UpdateSidebarCategories("user_id", "team_id", inputCategories)
 
 		require.Equal(t, appErr, err)
 	})

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang/mock v1.4.4
 	github.com/gorilla/mux v1.8.0
 	github.com/lib/pq v1.10.2
-	github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210621071817-df224571d8a1
+	github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210625165209-b4f6cb8cb70f
 	github.com/nicksnyder/go-i18n/v2 v2.0.3
 	github.com/pkg/errors v0.9.1
 	github.com/rudderlabs/analytics-go v3.3.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,6 @@ github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d h1:/RJ/UV7M5c7L2TQ
 github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d/go.mod h1:HLbgMEI5K131jpxGazJ97AxfPDt31osq36YS1oxFQPQ=
 github.com/mattermost/logr v1.0.13 h1:6F/fM3csvH6Oy5sUpJuW7YyZSzZZAhJm5VcgKMxA2P8=
 github.com/mattermost/logr v1.0.13/go.mod h1:Mt4DPu1NXMe6JxPdwCC0XBoxXmN9eXOIRPoZarU2PXs=
-github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210621071817-df224571d8a1 h1:5/lZibP83SrOpuKs4fE782pfWNFX/QTWwO2PuJJwGJ4=
-github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210621071817-df224571d8a1/go.mod h1:S3zT7H4bAxsev1d2ThoSRBhyEXZa6JZOfpxvy2B25y4=
 github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210625165209-b4f6cb8cb70f h1:YjUDJXa5/bpq5slsup+0TtbHIFWZV5cs+PNWuxyX5VY=
 github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210625165209-b4f6cb8cb70f/go.mod h1:S3zT7H4bAxsev1d2ThoSRBhyEXZa6JZOfpxvy2B25y4=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=

--- a/go.sum
+++ b/go.sum
@@ -589,6 +589,8 @@ github.com/mattermost/logr v1.0.13 h1:6F/fM3csvH6Oy5sUpJuW7YyZSzZZAhJm5VcgKMxA2P
 github.com/mattermost/logr v1.0.13/go.mod h1:Mt4DPu1NXMe6JxPdwCC0XBoxXmN9eXOIRPoZarU2PXs=
 github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210621071817-df224571d8a1 h1:5/lZibP83SrOpuKs4fE782pfWNFX/QTWwO2PuJJwGJ4=
 github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210621071817-df224571d8a1/go.mod h1:S3zT7H4bAxsev1d2ThoSRBhyEXZa6JZOfpxvy2B25y4=
+github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210625165209-b4f6cb8cb70f h1:YjUDJXa5/bpq5slsup+0TtbHIFWZV5cs+PNWuxyX5VY=
+github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210625165209-b4f6cb8cb70f/go.mod h1:S3zT7H4bAxsev1d2ThoSRBhyEXZa6JZOfpxvy2B25y4=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=


### PR DESCRIPTION
#### Summary

Add CreateSidebarCategory, GetSidebarCategories and UpdateSidebarCategories to PluginAPI Channel Service

#### Ticket Link

JIRA: https://mattermost.atlassian.net/browse/MM-32421

#### Release Note

```release-note
Added CreateSidebarCategory, GetSidebarCategories and UpdateSidebarCategories to PluginAPI Channel Service
```