### PR TITLE
Revert "Add DB RPC API support to client (#93)"

### DIFF
--- a/bot_test.go
+++ b/bot_test.go
@@ -19,7 +19,7 @@ func TestCreateBot(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("CreateBot", &model.Bot{Username: "1"}).Return(&model.Bot{Username: "1", UserId: "2"}, nil)
 
@@ -32,7 +32,7 @@ func TestCreateBot(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := newAppError()
 
@@ -49,7 +49,7 @@ func TestUpdateBotStatus(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("UpdateBotActive", "1", true).Return(&model.Bot{UserId: "2"}, nil)
 
@@ -61,7 +61,7 @@ func TestUpdateBotStatus(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := newAppError()
 
@@ -77,7 +77,7 @@ func TestSetBotIconImage(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("SetBotIconImage", "1", []byte{2}).Return(nil)
 
@@ -88,7 +88,7 @@ func TestSetBotIconImage(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := newAppError()
 
@@ -103,7 +103,7 @@ func TestGetBot(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetBot", "1", true).Return(&model.Bot{UserId: "2"}, nil)
 
@@ -115,7 +115,7 @@ func TestGetBot(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := newAppError()
 
@@ -131,7 +131,7 @@ func TestGetBotIconImage(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetBotIconImage", "1").Return([]byte{2}, nil)
 
@@ -145,7 +145,7 @@ func TestGetBotIconImage(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := newAppError()
 
@@ -239,7 +239,7 @@ func TestListBot(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			api := &plugintest.API{}
-			client := pluginapi.NewClient(api, &plugintest.Driver{})
+			client := pluginapi.NewClient(api)
 
 			api.On("GetBots", test.expectedOptions).Return(test.bots, test.err)
 
@@ -260,7 +260,7 @@ func TestDeleteBotIconImage(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("DeleteBotIconImage", "1").Return(nil)
 
@@ -271,7 +271,7 @@ func TestDeleteBotIconImage(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := newAppError()
 
@@ -286,7 +286,7 @@ func TestDeleteBotPermanently(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("PermanentDeleteBot", "1").Return(nil)
 
@@ -297,7 +297,7 @@ func TestDeleteBotPermanently(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := newAppError()
 
@@ -318,7 +318,7 @@ func TestEnsureBot(t *testing.T) {
 	t.Run("server version incompatible", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetServerVersion").Return("5.9.0")
 
@@ -333,7 +333,7 @@ func TestEnsureBot(t *testing.T) {
 	t.Run("bad parameters", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetServerVersion").Return("5.10.0")
 
@@ -356,7 +356,7 @@ func TestEnsureBot(t *testing.T) {
 		t.Run("should find and return the existing bot ID", func(t *testing.T) {
 			api := &plugintest.API{}
 			defer api.AssertExpectations(t)
-			client := pluginapi.NewClient(api, &plugintest.Driver{})
+			client := pluginapi.NewClient(api)
 
 			expectedBotID := model.NewId()
 
@@ -377,7 +377,7 @@ func TestEnsureBot(t *testing.T) {
 		t.Run("should return an error if unable to get bot", func(t *testing.T) {
 			api := &plugintest.API{}
 			defer api.AssertExpectations(t)
-			client := pluginapi.NewClient(api, &plugintest.Driver{})
+			client := pluginapi.NewClient(api)
 
 			api.On("GetServerVersion").Return("5.10.0")
 			api.On("KVGet", plugin.BotUserKey).Return(nil, &model.AppError{})
@@ -391,7 +391,7 @@ func TestEnsureBot(t *testing.T) {
 		t.Run("should set the bot profile image when specified", func(t *testing.T) {
 			api := &plugintest.API{}
 			defer api.AssertExpectations(t)
-			client := pluginapi.NewClient(api, &plugintest.Driver{})
+			client := pluginapi.NewClient(api)
 
 			expectedBotID := model.NewId()
 
@@ -420,7 +420,7 @@ func TestEnsureBot(t *testing.T) {
 		t.Run("should set the bot icon image when specified", func(t *testing.T) {
 			api := &plugintest.API{}
 			defer api.AssertExpectations(t)
-			client := pluginapi.NewClient(api, &plugintest.Driver{})
+			client := pluginapi.NewClient(api)
 
 			expectedBotID := model.NewId()
 
@@ -449,7 +449,7 @@ func TestEnsureBot(t *testing.T) {
 		t.Run("should set both the profile image and bot icon image when specified", func(t *testing.T) {
 			api := &plugintest.API{}
 			defer api.AssertExpectations(t)
-			client := pluginapi.NewClient(api, &plugintest.Driver{})
+			client := pluginapi.NewClient(api)
 
 			expectedBotID := model.NewId()
 
@@ -490,7 +490,7 @@ func TestEnsureBot(t *testing.T) {
 		t.Run("should find and update the bot with new bot details", func(t *testing.T) {
 			api := &plugintest.API{}
 			defer api.AssertExpectations(t)
-			client := pluginapi.NewClient(api, &plugintest.Driver{})
+			client := pluginapi.NewClient(api)
 
 			expectedBotID := model.NewId()
 			expectedBotUsername := "updated_testbot"
@@ -541,7 +541,7 @@ func TestEnsureBot(t *testing.T) {
 		t.Run("should create the bot and return the ID", func(t *testing.T) {
 			api := &plugintest.API{}
 			defer api.AssertExpectations(t)
-			client := pluginapi.NewClient(api, &plugintest.Driver{})
+			client := pluginapi.NewClient(api)
 
 			expectedBotID := model.NewId()
 
@@ -561,7 +561,7 @@ func TestEnsureBot(t *testing.T) {
 		t.Run("should claim existing bot and return the ID", func(t *testing.T) {
 			api := &plugintest.API{}
 			defer api.AssertExpectations(t)
-			client := pluginapi.NewClient(api, &plugintest.Driver{})
+			client := pluginapi.NewClient(api)
 
 			expectedBotID := model.NewId()
 
@@ -581,7 +581,7 @@ func TestEnsureBot(t *testing.T) {
 		t.Run("should return the non-bot account but log a message if user exists with the same name and is not a bot", func(t *testing.T) {
 			api := &plugintest.API{}
 			defer api.AssertExpectations(t)
-			client := pluginapi.NewClient(api, &plugintest.Driver{})
+			client := pluginapi.NewClient(api)
 
 			expectedBotID := model.NewId()
 
@@ -601,7 +601,7 @@ func TestEnsureBot(t *testing.T) {
 		t.Run("should fail if create bot fails", func(t *testing.T) {
 			api := &plugintest.API{}
 			defer api.AssertExpectations(t)
-			client := pluginapi.NewClient(api, &plugintest.Driver{})
+			client := pluginapi.NewClient(api)
 
 			api.On("GetServerVersion").Return("5.10.0")
 			api.On("KVGet", plugin.BotUserKey).Return(nil, nil)
@@ -616,7 +616,7 @@ func TestEnsureBot(t *testing.T) {
 		t.Run("should create bot and set the bot profile image when specified", func(t *testing.T) {
 			api := &plugintest.API{}
 			defer api.AssertExpectations(t)
-			client := pluginapi.NewClient(api, &plugintest.Driver{})
+			client := pluginapi.NewClient(api)
 
 			expectedBotID := model.NewId()
 
@@ -645,7 +645,7 @@ func TestEnsureBot(t *testing.T) {
 		t.Run("should create bot and set the bot icon image when specified", func(t *testing.T) {
 			api := &plugintest.API{}
 			defer api.AssertExpectations(t)
-			client := pluginapi.NewClient(api, &plugintest.Driver{})
+			client := pluginapi.NewClient(api)
 
 			expectedBotID := model.NewId()
 
@@ -674,7 +674,7 @@ func TestEnsureBot(t *testing.T) {
 		t.Run("should create bot and set both the profile image and bot icon image when specified", func(t *testing.T) {
 			api := &plugintest.API{}
 			defer api.AssertExpectations(t)
-			client := pluginapi.NewClient(api, &plugintest.Driver{})
+			client := pluginapi.NewClient(api)
 
 			expectedBotID := model.NewId()
 

--- a/channel_test.go
+++ b/channel_test.go
@@ -15,7 +15,7 @@ func TestGetMembers(t *testing.T) {
 	t.Run("empty list", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetChannelMembers", "channelID", 1, 10).Return(nil, nil)
 
@@ -29,7 +29,7 @@ func TestGetTeamChannelByName(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetChannelByNameForTeamName", "1", "2", true).Return(&model.Channel{TeamId: "3"}, nil)
 
@@ -41,7 +41,7 @@ func TestGetTeamChannelByName(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetChannelByNameForTeamName", "1", "2", true).Return(nil, newAppError())
 
@@ -55,7 +55,7 @@ func TestGetTeamUserChannels(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetChannelsForTeamForUser", "1", "2", true).Return([]*model.Channel{{TeamId: "3"}, {TeamId: "4"}}, nil)
 
@@ -67,7 +67,7 @@ func TestGetTeamUserChannels(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 
@@ -83,7 +83,7 @@ func TestGetPublicTeamChannels(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetPublicChannelsForTeam", "1", 2, 3).Return([]*model.Channel{{TeamId: "3"}, {TeamId: "4"}}, nil)
 
@@ -95,7 +95,7 @@ func TestGetPublicTeamChannels(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 
@@ -111,7 +111,7 @@ func TestCreateChannel(t *testing.T) {
 	t.Run("create channel with no replicas", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		config := &model.Config{
 			SqlSettings: model.SqlSettings{
@@ -134,7 +134,7 @@ func TestCreateChannel(t *testing.T) {
 	t.Run("create channel and wait once", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		config := &model.Config{
 			SqlSettings: model.SqlSettings{
@@ -158,7 +158,7 @@ func TestCreateChannel(t *testing.T) {
 	t.Run("create channel and wait multiple times", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		config := &model.Config{
 			SqlSettings: model.SqlSettings{
@@ -185,7 +185,7 @@ func TestCreateChannel(t *testing.T) {
 	t.Run("create channel, wait multiple times and return error", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		config := &model.Config{
 			SqlSettings: model.SqlSettings{
@@ -214,7 +214,7 @@ func TestCreateChannel(t *testing.T) {
 	t.Run("create channel, give up waiting", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		config := &model.Config{
 			SqlSettings: model.SqlSettings{
@@ -243,7 +243,7 @@ func TestCreateSidebarCategory(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		category := model.SidebarCategoryWithChannels{}
 
@@ -270,7 +270,7 @@ func TestCreateSidebarCategory(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		inputCategory := model.SidebarCategoryWithChannels{}
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
@@ -288,7 +288,7 @@ func TestGetSidebarCategories(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetChannelSidebarCategories", "user_id", "team_id").
 			Return(&model.OrderedSidebarCategories{
@@ -311,7 +311,7 @@ func TestGetSidebarCategories(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 
@@ -326,7 +326,7 @@ func TestGetSidebarCategories(t *testing.T) {
 func TestUpdateSidebarCategories(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		categories := []*model.SidebarCategoryWithChannels{
 			{
@@ -354,7 +354,7 @@ func TestUpdateSidebarCategories(t *testing.T) {
 
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		inputCategories := []*model.SidebarCategoryWithChannels{
 			{

--- a/client.go
+++ b/client.go
@@ -34,8 +34,8 @@ type Client struct {
 // NewClient creates a new instance of Client.
 //
 // This client must only be created once per plugin to
-// prevent reacquiring of resources.
-func NewClient(api plugin.API, driver plugin.Driver) *Client {
+// prevent reacquiring of resources, such as database connections.
+func NewClient(api plugin.API) *Client {
 	return &Client{
 		api: api,
 
@@ -54,13 +54,10 @@ func NewClient(api plugin.API, driver plugin.Driver) *Client {
 		Plugin:        PluginService{api: api},
 		Post:          PostService{api: api},
 		Session:       SessionService{api: api},
-		Store: &StoreService{
-			api:    api,
-			driver: driver,
-		},
-		System: SystemService{api: api},
-		Team:   TeamService{api: api},
-		User:   UserService{api: api},
+		Store:         &StoreService{api: api},
+		System:        SystemService{api: api},
+		Team:          TeamService{api: api},
+		User:          UserService{api: api},
 	}
 }
 

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -104,7 +104,7 @@ func TestCheckRequiredServerConfiguration(t *testing.T) {
 			api := test.SetupAPI(&plugintest.API{})
 			defer api.AssertExpectations(t)
 
-			client := pluginapi.NewClient(api, &plugintest.Driver{})
+			client := pluginapi.NewClient(api)
 
 			ok, err := client.Configuration.CheckRequiredServerConfiguration(test.Input)
 

--- a/emoji_test.go
+++ b/emoji_test.go
@@ -15,7 +15,7 @@ func TestGetEmoji(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetEmoji", "1").Return(&model.Emoji{Id: "2"}, nil)
 
@@ -27,7 +27,7 @@ func TestGetEmoji(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := newAppError()
 
@@ -43,7 +43,7 @@ func TestGetEmojiByName(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetEmojiByName", "1").Return(&model.Emoji{Id: "2"}, nil)
 
@@ -55,7 +55,7 @@ func TestGetEmojiByName(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := newAppError()
 
@@ -71,7 +71,7 @@ func TestGetEmojiImage(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetEmojiImage", "1").Return([]byte{1}, "jpg", nil)
 
@@ -86,7 +86,7 @@ func TestGetEmojiImage(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := newAppError()
 
@@ -103,7 +103,7 @@ func TestListEmojis(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetEmojiList", "1", 2, 3).Return([]*model.Emoji{
 			{Id: "4"},
@@ -118,7 +118,7 @@ func TestListEmojis(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := newAppError()
 

--- a/example_client_test.go
+++ b/example_client_test.go
@@ -12,7 +12,7 @@ type Plugin struct {
 }
 
 func (p *Plugin) OnActivate() error {
-	p.client = pluginapi.NewClient(p.API, p.Driver)
+	p.client = pluginapi.NewClient(p.API)
 
 	return nil
 }

--- a/experimental/bot/poster/default_poster_test.go
+++ b/experimental/bot/poster/default_poster_test.go
@@ -22,8 +22,7 @@ const (
 func TestInterface(t *testing.T) {
 	t.Run("Plugin API satisfy the interface", func(t *testing.T) {
 		api := &plugintest.API{}
-		driver := &plugintest.Driver{}
-		client := pluginapi.NewClient(api, driver)
+		client := pluginapi.NewClient(api)
 		_ = NewPoster(&client.Post, botID)
 	})
 }

--- a/file_test.go
+++ b/file_test.go
@@ -16,7 +16,7 @@ func TestGetFile(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetFile", "1").Return([]byte{2}, nil)
 
@@ -30,7 +30,7 @@ func TestGetFile(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := newAppError()
 
@@ -46,7 +46,7 @@ func TestGetFileByPath(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("ReadFile", "1").Return([]byte{2}, nil)
 
@@ -60,7 +60,7 @@ func TestGetFileByPath(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := newAppError()
 
@@ -76,7 +76,7 @@ func TestGetFileInfo(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetFileInfo", "1").Return(&model.FileInfo{Id: "2"}, nil)
 
@@ -88,7 +88,7 @@ func TestGetFileInfo(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := newAppError()
 
@@ -104,7 +104,7 @@ func TestGetFileLink(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetFileLink", "1").Return("2", nil)
 
@@ -116,7 +116,7 @@ func TestGetFileLink(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := newAppError()
 
@@ -132,7 +132,7 @@ func TestUploadFile(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("UploadFile", []byte{1}, "3", "2").Return(&model.FileInfo{Id: "4"}, nil)
 
@@ -144,7 +144,7 @@ func TestUploadFile(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := newAppError()
 
@@ -160,7 +160,7 @@ func TestCopyFileInfos(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("CopyFileInfos", "3", []string{"1", "2"}).Return([]string{"4", "5"}, nil)
 
@@ -172,7 +172,7 @@ func TestCopyFileInfos(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := newAppError()
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210714130822-54b0ef574b5d
 	github.com/nicksnyder/go-i18n/v2 v2.0.3
 	github.com/pkg/errors v0.9.1
+	github.com/proullon/ramsql v0.0.0-20181213202341-817cee58a244
 	github.com/rudderlabs/analytics-go v3.3.1+incompatible
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -232,6 +232,7 @@ github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsouza/fake-gcs-server v1.17.0/go.mod h1:D1rTE4YCyHFNa99oyJJ5HyclvN/0uQR+pM/VdlL83bw=
 github.com/garyburd/redigo v1.6.0/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
@@ -252,6 +253,8 @@ github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-gorp/gorp v2.0.0+incompatible h1:dIQPsBtl6/H1MjVseWuWPXa7ET4p6Dve4j3Hg+UjqYw=
+github.com/go-gorp/gorp v2.0.0+incompatible/go.mod h1:7IfkAQnO7jfT/9IQ3R9wL1dFhukN6aQxzKTHnkxzA/E=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
@@ -585,6 +588,7 @@ github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJKjyR5WD3HYQSd+U=
 github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -646,6 +650,7 @@ github.com/ngdinhtoan/glide-cleanup v0.2.0/go.mod h1:UQzsmiDOb8YV3nOsCxK/c9zPpCZ
 github.com/nicksnyder/go-i18n/v2 v2.0.3 h1:ks/JkQiOEhhuF6jpNvx+Wih1NIiXzUnZeZVnJuI8R8M=
 github.com/nicksnyder/go-i18n/v2 v2.0.3/go.mod h1:oDab7q8XCYMRlcrBnaY/7B1eOectbvj6B1UPBT+p5jo=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
+github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
@@ -662,12 +667,14 @@ github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1lskyM0=
 github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
+github.com/onsi/ginkgo v1.15.0 h1:1V1NfVQR87RtWAgp1lv9JZJ5Jap+XFGKPi00andXGi4=
 github.com/onsi/ginkgo v1.15.0/go.mod h1:hF8qUzuuC8DJGygJH3726JnCZX4MYbRB8yFfISqnKUg=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/onsi/gomega v1.10.5 h1:7n6FEkpFmfCoo2t+YYqXH0evK+a9ICQz0xcAy9dYcaQ=
 github.com/onsi/gomega v1.10.5/go.mod h1:gza4q3jKQJijlu05nKWRCW/GavJumGt8aNRxWg7mt48=
 github.com/oov/psd v0.0.0-20210618170533-9fb823ddb631/go.mod h1:GHI1bnmAcbp96z6LNfBJvtrjxhaXGkbsk967utPlvL8=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
@@ -736,6 +743,8 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/proullon/ramsql v0.0.0-20181213202341-817cee58a244 h1:fdX2U+a2Rmc4BjRYcOKzjYXtYTE4ga1B2lb8i7BlefU=
+github.com/proullon/ramsql v0.0.0-20181213202341-817cee58a244/go.mod h1:jG8oAQG0ZPHPyxg5QlMERS31airDC+ZuqiAe8DUvFVo=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/reflog/dateconstraints v0.2.1/go.mod h1:Ax8AxTBcJc3E/oVS2hd2j7RDM/5MDtuPwuR7lIHtPLo=
@@ -913,6 +922,7 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.3.8 h1:Nw158Q8QN+CPgTmVRByhVwapp8Mm1e2blinhmx4wx5E=
 github.com/yuin/goldmark v1.3.8/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
+github.com/ziutek/mymysql v1.5.4 h1:GB0qdRGsTwQSBVYuVShFBKaXSnSnYYC2d9knnE1LHFs=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
 gitlab.com/nyarla/go-crypt v0.0.0-20160106005555-d9a5dc2b789b/go.mod h1:T3BPAOm2cqquPa0MKWeNkmOM5RQsRhkrwMWonFMN7fE=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -1380,6 +1390,7 @@ gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXL
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/olivere/elastic.v6 v6.2.35/go.mod h1:2cTT8Z+/LcArSWpCgvZqBgt3VOqXiy7v00w12Lz8bd4=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/kv_test.go
+++ b/kv_test.go
@@ -138,7 +138,7 @@ func TestKVSet(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			api := &plugintest.API{}
-			client := pluginapi.NewClient(api, &plugintest.Driver{})
+			client := pluginapi.NewClient(api)
 
 			api.On("KVSetWithOptions", test.key, test.expectedValue, test.expectedOptions).Return(test.upserted, test.err)
 
@@ -158,7 +158,7 @@ func TestKVSet(t *testing.T) {
 func TestSetWithExpiry(t *testing.T) {
 	api := &plugintest.API{}
 	defer api.AssertExpectations(t)
-	client := pluginapi.NewClient(api, &plugintest.Driver{})
+	client := pluginapi.NewClient(api)
 
 	api.On("KVSetWithOptions", "1", []byte(`2`), model.PluginKVSetOptions{
 		ExpireInSeconds: 60,
@@ -171,7 +171,7 @@ func TestSetWithExpiry(t *testing.T) {
 func TestCompareAndSet(t *testing.T) {
 	api := &plugintest.API{}
 	defer api.AssertExpectations(t)
-	client := pluginapi.NewClient(api, &plugintest.Driver{})
+	client := pluginapi.NewClient(api)
 
 	api.On("KVSetWithOptions", "1", []byte("2"), model.PluginKVSetOptions{
 		Atomic:   true,
@@ -186,7 +186,7 @@ func TestCompareAndSet(t *testing.T) {
 func TestCompareAndDelete(t *testing.T) {
 	api := &plugintest.API{}
 	defer api.AssertExpectations(t)
-	client := pluginapi.NewClient(api, &plugintest.Driver{})
+	client := pluginapi.NewClient(api)
 
 	api.On("KVSetWithOptions", "1", []byte(nil), model.PluginKVSetOptions{
 		Atomic:   true,
@@ -442,7 +442,7 @@ func TestSetAtomicWithRetries(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			api := &plugintest.API{}
 			defer api.AssertExpectations(t)
-			client := pluginapi.NewClient(api, &plugintest.Driver{})
+			client := pluginapi.NewClient(api)
 
 			tt.setupAPI(api)
 
@@ -462,7 +462,7 @@ func TestSetAtomicWithRetries(t *testing.T) {
 func TestGet(t *testing.T) {
 	api := &plugintest.API{}
 	defer api.AssertExpectations(t)
-	client := pluginapi.NewClient(api, &plugintest.Driver{})
+	client := pluginapi.NewClient(api)
 
 	aStringJSON, _ := json.Marshal("2")
 
@@ -477,7 +477,7 @@ func TestGet(t *testing.T) {
 func TestGetNilKey(t *testing.T) {
 	api := &plugintest.API{}
 	defer api.AssertExpectations(t)
-	client := pluginapi.NewClient(api, &plugintest.Driver{})
+	client := pluginapi.NewClient(api)
 
 	api.On("KVGet", "1").Return(nil, nil)
 
@@ -490,7 +490,7 @@ func TestGetNilKey(t *testing.T) {
 func TestGetInBytes(t *testing.T) {
 	api := &plugintest.API{}
 	defer api.AssertExpectations(t)
-	client := pluginapi.NewClient(api, &plugintest.Driver{})
+	client := pluginapi.NewClient(api)
 
 	api.On("KVGet", "1").Return([]byte{2}, nil)
 
@@ -504,7 +504,7 @@ func TestGetInBytes(t *testing.T) {
 func TestDelete(t *testing.T) {
 	api := &plugintest.API{}
 	defer api.AssertExpectations(t)
-	client := pluginapi.NewClient(api, &plugintest.Driver{})
+	client := pluginapi.NewClient(api)
 
 	api.On("KVSetWithOptions", "1", []byte(nil), model.PluginKVSetOptions{}).Return(true, nil)
 
@@ -515,7 +515,7 @@ func TestDelete(t *testing.T) {
 func TestDeleteAll(t *testing.T) {
 	api := &plugintest.API{}
 	defer api.AssertExpectations(t)
-	client := pluginapi.NewClient(api, &plugintest.Driver{})
+	client := pluginapi.NewClient(api)
 
 	api.On("KVDeleteAll").Return(nil)
 
@@ -527,7 +527,7 @@ func TestListKeys(t *testing.T) {
 	t.Run("No keys", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("KVList", 0, 100).Return(nil, nil)
 
@@ -540,7 +540,7 @@ func TestListKeys(t *testing.T) {
 	t.Run("Basic Success, one page", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("KVList", 1, 2).Return(getKeys(2), nil)
 
@@ -552,7 +552,7 @@ func TestListKeys(t *testing.T) {
 	t.Run("success, two page, filter prefix, one", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("KVList", 0, 100).Return(getKeys(100), nil)
 
@@ -564,7 +564,7 @@ func TestListKeys(t *testing.T) {
 	t.Run("success, two page, filter prefix, all", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("KVList", 0, 100).Return(getKeys(100), nil)
 
@@ -576,7 +576,7 @@ func TestListKeys(t *testing.T) {
 	t.Run("success, two page, filter prefix, none", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("KVList", 0, 100).Return(getKeys(100), nil)
 
@@ -588,7 +588,7 @@ func TestListKeys(t *testing.T) {
 	t.Run("success, two page, checker func, one", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("KVList", 0, 100).Return(getKeys(100), nil)
 
@@ -607,7 +607,7 @@ func TestListKeys(t *testing.T) {
 	t.Run("success, two page, checker func, all", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("KVList", 0, 100).Return(getKeys(100), nil)
 
@@ -623,7 +623,7 @@ func TestListKeys(t *testing.T) {
 	t.Run("success, two page, checker func, none", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("KVList", 0, 100).Return(getKeys(100), nil)
 
@@ -639,7 +639,7 @@ func TestListKeys(t *testing.T) {
 	t.Run("error, checker func", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("KVList", 0, 100).Return([]string{"key1"}, nil)
 
@@ -655,7 +655,7 @@ func TestListKeys(t *testing.T) {
 	t.Run("success, filter and checker func, partial on both", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("KVList", 0, 100).Return([]string{"key1", "key2", "notkey3", "key4", "key5"}, nil)
 

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -31,7 +31,7 @@ func TestLogrus(t *testing.T) {
 
 			api := &plugintest.API{}
 			defer api.AssertExpectations(t)
-			client := pluginapi.NewClient(api, &plugintest.Driver{})
+			client := pluginapi.NewClient(api)
 
 			pluginapi.ConfigureLogrus(logger, client)
 

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -22,7 +22,7 @@ func TestInstallPluginFromURL(t *testing.T) {
 	t.Run("incompatible server version", func(t *testing.T) {
 		api := &plugintest.API{}
 		api.On("GetServerVersion").Return("5.1.0")
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		_, err := client.Plugin.InstallPluginFromURL("", true)
 
@@ -33,7 +33,7 @@ func TestInstallPluginFromURL(t *testing.T) {
 	t.Run("error while parsing the download url", func(t *testing.T) {
 		api := &plugintest.API{}
 		api.On("GetServerVersion").Return("5.19.0")
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		_, err := client.Plugin.InstallPluginFromURL("http://%41:8080/", replace)
 
@@ -44,7 +44,7 @@ func TestInstallPluginFromURL(t *testing.T) {
 	t.Run("errors out while downloading file", func(t *testing.T) {
 		api := &plugintest.API{}
 		api.On("GetServerVersion").Return("5.19.0")
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 			res.WriteHeader(http.StatusInternalServerError)
@@ -61,7 +61,7 @@ func TestInstallPluginFromURL(t *testing.T) {
 	t.Run("downloads the file successfully", func(t *testing.T) {
 		api := &plugintest.API{}
 		api.On("GetServerVersion").Return("5.19.0")
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		tarData, err := os.ReadFile(filepath.Join("tests", "testplugin.tar.gz"))
 		require.NoError(t, err)
@@ -84,7 +84,7 @@ func TestInstallPluginFromURL(t *testing.T) {
 	t.Run("the url pointing to server is incorrect", func(t *testing.T) {
 		api := &plugintest.API{}
 		api.On("GetServerVersion").Return("5.19.0")
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 		testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 			res.WriteHeader(http.StatusNotFound)
 		}))
@@ -103,7 +103,7 @@ func TestGetPluginAssetURL(t *testing.T) {
 	api := &plugintest.API{}
 	api.On("GetConfig").Return(&model.Config{ServiceSettings: model.ServiceSettings{SiteURL: &siteURL}})
 
-	client := pluginapi.NewClient(api, &plugintest.Driver{})
+	client := pluginapi.NewClient(api)
 
 	t.Run("Valid asset directory was provided", func(t *testing.T) {
 		pluginID := "mattermost-1234"

--- a/post_test.go
+++ b/post_test.go
@@ -17,7 +17,7 @@ func TestCreatePost(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		id := model.NewId()
 		in := &model.Post{
@@ -35,7 +35,7 @@ func TestCreatePost(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		in := &model.Post{
 			Id: "postID",
@@ -53,7 +53,7 @@ func TestGetPost(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		postID := "postID"
 		expectedPost := &model.Post{
@@ -69,7 +69,7 @@ func TestGetPost(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		postID := "postID"
 		api.On("GetPost", postID).Return(nil, newAppError())
@@ -84,7 +84,7 @@ func TestUpdatePost(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		now := model.GetMillis()
 		in := &model.Post{
@@ -102,7 +102,7 @@ func TestUpdatePost(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		in := &model.Post{
 			Id: "postID",
@@ -120,7 +120,7 @@ func TestDeletePost(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		postID := "postID"
 
@@ -133,7 +133,7 @@ func TestDeletePost(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		postID := "postID"
 		api.On("DeletePost", postID).Return(newAppError())
@@ -146,7 +146,7 @@ func TestDeletePost(t *testing.T) {
 func TestSendEphemeralPost(t *testing.T) {
 	api := &plugintest.API{}
 	defer api.AssertExpectations(t)
-	client := pluginapi.NewClient(api, &plugintest.Driver{})
+	client := pluginapi.NewClient(api)
 
 	userID := "userID"
 	expectedPost := &model.Post{
@@ -160,7 +160,7 @@ func TestSendEphemeralPost(t *testing.T) {
 func TestUpdateEphemeralPost(t *testing.T) {
 	api := &plugintest.API{}
 	defer api.AssertExpectations(t)
-	client := pluginapi.NewClient(api, &plugintest.Driver{})
+	client := pluginapi.NewClient(api)
 
 	now := model.GetMillis()
 	userID := "userID"
@@ -178,7 +178,7 @@ func TestUpdateEphemeralPost(t *testing.T) {
 func TestDeleteEphemeralPost(t *testing.T) {
 	api := &plugintest.API{}
 	defer api.AssertExpectations(t)
-	client := pluginapi.NewClient(api, &plugintest.Driver{})
+	client := pluginapi.NewClient(api)
 
 	userID := "userID"
 	postID := "postID"
@@ -191,7 +191,7 @@ func TestGetPostThread(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		postID := "postID"
 		expectedPostList := model.NewPostList()
@@ -207,7 +207,7 @@ func TestGetPostThread(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		postID := "postID"
 		api.On("GetPostThread", postID).Return(nil, newAppError())
@@ -222,7 +222,7 @@ func TestGetPostsSince(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		channelID := "channelID"
 		time := int64(0)
@@ -239,7 +239,7 @@ func TestGetPostsSince(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		channelID := "channelID"
 		time := int64(0)
@@ -255,7 +255,7 @@ func TestGetPostsAfter(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		channelID := "channelID"
 		postID := "postID"
@@ -272,7 +272,7 @@ func TestGetPostsAfter(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		channelID := "channelID"
 		postID := "postID"
@@ -288,7 +288,7 @@ func TestGetPostsBefore(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		channelID := "channelID"
 		postID := "postID"
@@ -305,7 +305,7 @@ func TestGetPostsBefore(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		channelID := "channelID"
 		postID := "postID"
@@ -321,7 +321,7 @@ func TestGetPostsForChannel(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		channelID := "channelID"
 		expectedPostList := model.NewPostList()
@@ -337,7 +337,7 @@ func TestGetPostsForChannel(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		channelID := "channelID"
 		api.On("GetPostsForChannel", channelID, 0, 0).Return(nil, newAppError())
@@ -352,7 +352,7 @@ func TestSearchPostsInTeam(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		teamID := "teamID"
 		searchParams := []*model.SearchParams{{InChannels: []string{"channelID"}}}
@@ -367,7 +367,7 @@ func TestSearchPostsInTeam(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		teamID := "teamID"
 		searchParams := []*model.SearchParams{{InChannels: []string{"channelID"}}}
@@ -383,7 +383,7 @@ func TestAddReaction(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		in := &model.Reaction{
 			PostId: "postId",
@@ -397,7 +397,7 @@ func TestAddReaction(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		in := &model.Reaction{
 			PostId: "postId",
@@ -413,7 +413,7 @@ func TestGetReactions(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		postID := "postID"
 		expectedReactions := []*model.Reaction{
@@ -430,7 +430,7 @@ func TestGetReactions(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		postID := "postID"
 		api.On("GetReactions", postID).Return(nil, newAppError())
@@ -445,7 +445,7 @@ func TestDeleteReaction(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		reaction := &model.Reaction{
 			PostId: "postId",
@@ -459,7 +459,7 @@ func TestDeleteReaction(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		reaction := &model.Reaction{
 			PostId: "postId",
@@ -475,7 +475,7 @@ func TestSearchTeamPosts(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("SearchPostsInTeam", "1", []*model.SearchParams{{Terms: "2"}, {Terms: "3"}}).
 			Return([]*model.Post{{Id: "3"}, {Id: "4"}}, nil)
@@ -488,7 +488,7 @@ func TestSearchTeamPosts(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 
@@ -511,7 +511,7 @@ func TestShouldProcessMessage(t *testing.T) {
 	t.Run("should not respond to itself", func(t *testing.T) {
 		api := setupAPI()
 		api.On("KVGet", plugin.BotUserKey).Return([]byte(expectedBotID), nil)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		shouldProcessMessage, err := client.Post.ShouldProcessMessage(
 			&model.Post{Type: model.POST_HEADER_CHANGE, UserId: expectedBotID},
@@ -526,7 +526,7 @@ func TestShouldProcessMessage(t *testing.T) {
 	t.Run("should not process as the post is generated by system", func(t *testing.T) {
 		api := setupAPI()
 		api.On("KVGet", plugin.BotUserKey).Return([]byte(expectedBotID), nil)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		shouldProcessMessage, err := client.Post.ShouldProcessMessage(
 			&model.Post{Type: model.POST_HEADER_CHANGE},
@@ -541,7 +541,7 @@ func TestShouldProcessMessage(t *testing.T) {
 		api := setupAPI()
 		api.On("GetChannel", channelID).Return(&model.Channel{Id: channelID, Type: model.CHANNEL_GROUP}, nil)
 		api.On("KVGet", plugin.BotUserKey).Return([]byte(expectedBotID), nil)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		shouldProcessMessage, err := client.Post.ShouldProcessMessage(
 			&model.Post{ChannelId: channelID}, pluginapi.AllowSystemMessages(),
@@ -559,7 +559,7 @@ func TestShouldProcessMessage(t *testing.T) {
 		api := setupAPI()
 		api.On("GetUser", userID).Return(&model.User{IsBot: true}, nil)
 		api.On("KVGet", plugin.BotUserKey).Return([]byte(expectedBotID), nil)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		shouldProcessMessage, err := client.Post.ShouldProcessMessage(
 			&model.Post{UserId: userID, ChannelId: channelID},
@@ -581,7 +581,7 @@ func TestShouldProcessMessage(t *testing.T) {
 		api := setupAPI()
 		api.On("GetChannel", channelID).Return(&channel, nil)
 		api.On("KVGet", plugin.BotUserKey).Return([]byte(expectedBotID), nil)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		shouldProcessMessage, err := client.Post.ShouldProcessMessage(
 			&model.Post{UserId: userID, ChannelId: channelID},
@@ -598,7 +598,7 @@ func TestShouldProcessMessage(t *testing.T) {
 		channelID := "1"
 		api := setupAPI()
 		api.On("KVGet", plugin.BotUserKey).Return([]byte(expectedBotID), nil)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		shouldProcessMessage, err := client.Post.ShouldProcessMessage(
 			&model.Post{UserId: "1", Type: model.POST_HEADER_CHANGE, ChannelId: channelID},
@@ -616,7 +616,7 @@ func TestShouldProcessMessage(t *testing.T) {
 		channelID := "1"
 		api := setupAPI()
 		api.On("KVGet", plugin.BotUserKey).Return(nil, nil)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		shouldProcessMessage, err := client.Post.ShouldProcessMessage(
 			&model.Post{UserId: "1", Type: model.POST_HEADER_CHANGE, ChannelId: channelID},
@@ -639,7 +639,7 @@ func TestShouldProcessMessage(t *testing.T) {
 		}
 		api.On("GetChannel", channelID).Return(&channel, nil)
 		api.On("KVGet", plugin.BotUserKey).Return([]byte(expectedBotID), nil)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		shouldProcessMessage, err := client.Post.ShouldProcessMessage(
 			&model.Post{UserId: "1", Type: model.POST_HEADER_CHANGE, ChannelId: channelID},
@@ -658,7 +658,7 @@ func TestShouldProcessMessage(t *testing.T) {
 
 		api.On("KVGet", plugin.BotUserKey).Return([]byte(expectedBotID), nil)
 
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 		shouldProcessMessage, err := client.Post.ShouldProcessMessage(
 			&model.Post{ChannelId: channelID, Props: model.StringInterface{"from_webhook": "true"}},
 			pluginapi.AllowBots(),
@@ -674,7 +674,7 @@ func TestShouldProcessMessage(t *testing.T) {
 		api.On("GetChannel", channelID).Return(&model.Channel{Id: channelID, Type: model.CHANNEL_GROUP}, nil)
 
 		api.On("KVGet", plugin.BotUserKey).Return([]byte(expectedBotID), nil)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		shouldProcessMessage, err := client.Post.ShouldProcessMessage(
 			&model.Post{ChannelId: channelID, Props: model.StringInterface{"from_webhook": "true"}},
@@ -692,7 +692,7 @@ func TestShouldProcessMessage(t *testing.T) {
 		api.On("GetChannel", channelID).Return(&model.Channel{Id: channelID, Type: model.CHANNEL_GROUP}, nil)
 
 		api.On("KVGet", plugin.BotUserKey).Return([]byte(expectedBotID), nil)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		shouldProcessMessage, err := client.Post.ShouldProcessMessage(
 			&model.Post{ChannelId: channelID},
@@ -709,7 +709,7 @@ func TestShouldProcessMessage(t *testing.T) {
 		api.On("GetChannel", channelID).Return(&model.Channel{Id: channelID, Type: model.CHANNEL_GROUP}, nil)
 
 		api.On("KVGet", plugin.BotUserKey).Return([]byte(expectedBotID), nil)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		shouldProcessMessage, err := client.Post.ShouldProcessMessage(
 			&model.Post{ChannelId: channelID, Props: model.StringInterface{"from_webhook": "false"}},
@@ -728,7 +728,7 @@ func TestShouldProcessMessage(t *testing.T) {
 
 		api.On("GetUser", userID).Return(&model.User{IsBot: false}, nil)
 
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		shouldProcessMessage, err := client.Post.ShouldProcessMessage(
 			&model.Post{ChannelId: channelID, UserId: userID},

--- a/store_test.go
+++ b/store_test.go
@@ -1,6 +1,7 @@
 package pluginapi_test
 
 import (
+	"database/sql"
 	"testing"
 
 	pluginapi "github.com/mattermost/mattermost-plugin-api"
@@ -8,15 +9,21 @@ import (
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
 
+	_ "github.com/proullon/ramsql/driver"
 	"github.com/stretchr/testify/require"
 )
 
 func TestStore(t *testing.T) {
 	t.Run("master db singleton", func(t *testing.T) {
+		db, err := sql.Open("ramsql", "TestStore-master-db")
+		require.NoError(t, err)
+		defer db.Close()
+
 		config := &model.Config{
 			SqlSettings: model.SqlSettings{
-				DriverName: model.NewString("test"),
-				DataSource: model.NewString("TestStore-master-db"),
+				DriverName:                  model.NewString("ramsql"),
+				DataSource:                  model.NewString("TestStore-master-db"),
+				ConnMaxLifetimeMilliseconds: model.NewInt(2),
 			},
 		}
 
@@ -24,12 +31,7 @@ func TestStore(t *testing.T) {
 		defer api.AssertExpectations(t)
 		api.On("GetUnsanitizedConfig").Return(config)
 
-		driver := &plugintest.Driver{}
-		driver.On("Conn", true).Return("test", nil)
-		driver.On("ConnPing", "test").Return(nil)
-		driver.On("ConnClose", "test").Return(nil)
-
-		store := pluginapi.NewClient(api, driver).Store
+		store := pluginapi.NewClient(api).Store
 
 		db1, err := store.GetMasterDB()
 		require.NoError(t, err)
@@ -43,7 +45,16 @@ func TestStore(t *testing.T) {
 		require.NoError(t, store.Close())
 	})
 
-	t.Run("master db fallback", func(t *testing.T) {
+	t.Run("master db", func(t *testing.T) {
+		db, err := sql.Open("ramsql", "TestStore-master-db")
+		require.NoError(t, err)
+		defer db.Close()
+
+		_, err = db.Exec("CREATE TABLE test (id INT);")
+		require.NoError(t, err)
+		_, err = db.Exec("INSERT INTO test (id) VALUES (2);")
+		require.NoError(t, err)
+
 		config := &model.Config{
 			SqlSettings: model.SqlSettings{
 				DriverName:                  model.NewString("ramsql"),
@@ -52,19 +63,19 @@ func TestStore(t *testing.T) {
 			},
 		}
 
-		driver := &plugintest.Driver{}
-		driver.On("Conn", true).Return("test", nil)
-		driver.On("ConnPing", "test").Return(nil)
-		driver.On("ConnClose", "test").Return(nil)
-
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		store := pluginapi.NewClient(api, driver).Store
+		store := pluginapi.NewClient(api).Store
 
 		api.On("GetUnsanitizedConfig").Return(config)
 		masterDB, err := store.GetMasterDB()
 		require.NoError(t, err)
 		require.NotNil(t, masterDB)
+
+		var id int
+		err = masterDB.QueryRow("SELECT id FROM test").Scan(&id)
+		require.NoError(t, err)
+		require.Equal(t, 2, id)
 
 		// No replica is set up, should fallback to master
 		replicaDB, err := store.GetReplicaDB()
@@ -75,6 +86,10 @@ func TestStore(t *testing.T) {
 	})
 
 	t.Run("replica db singleton", func(t *testing.T) {
+		db, err := sql.Open("ramsql", "TestStore-master-db")
+		require.NoError(t, err)
+		defer db.Close()
+
 		config := &model.Config{
 			SqlSettings: model.SqlSettings{
 				DriverName:                  model.NewString("ramsql"),
@@ -88,13 +103,7 @@ func TestStore(t *testing.T) {
 		defer api.AssertExpectations(t)
 		api.On("GetUnsanitizedConfig").Return(config)
 
-		driver := &plugintest.Driver{}
-		driver.On("Conn", true).Return("test", nil)
-		driver.On("Conn", false).Return("test", nil)
-		driver.On("ConnPing", "test").Return(nil)
-		driver.On("ConnClose", "test").Return(nil)
-
-		store := pluginapi.NewClient(api, driver).Store
+		store := pluginapi.NewClient(api).Store
 
 		db1, err := store.GetReplicaDB()
 		require.NoError(t, err)
@@ -105,6 +114,58 @@ func TestStore(t *testing.T) {
 		require.NotNil(t, db2)
 
 		require.Same(t, db1, db2)
+		require.NoError(t, store.Close())
+	})
+
+	t.Run("replica db", func(t *testing.T) {
+		masterDB, err := sql.Open("ramsql", "TestStore-replica-db-1")
+		require.NoError(t, err)
+		defer masterDB.Close()
+
+		_, err = masterDB.Exec("CREATE TABLE test (id INT);")
+		require.NoError(t, err)
+
+		replicaDB, err := sql.Open("ramsql", "TestStore-replica-db-2")
+		require.NoError(t, err)
+		defer masterDB.Close()
+
+		_, err = replicaDB.Exec("CREATE TABLE test (id INT);")
+		require.NoError(t, err)
+		_, err = replicaDB.Exec("INSERT INTO test (id) VALUES (3);")
+		require.NoError(t, err)
+
+		config := &model.Config{
+			SqlSettings: model.SqlSettings{
+				DriverName:                  model.NewString("ramsql"),
+				DataSource:                  model.NewString("TestStore-replica-db-1"),
+				DataSourceReplicas:          []string{"TestStore-replica-db-2"},
+				ConnMaxLifetimeMilliseconds: model.NewInt(2),
+			},
+		}
+
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+		store := pluginapi.NewClient(api).Store
+
+		api.On("GetUnsanitizedConfig").Return(config)
+		storeMasterDB, err := store.GetMasterDB()
+		require.NoError(t, err)
+		require.NotNil(t, storeMasterDB)
+
+		var count int
+		err = storeMasterDB.QueryRow("SELECT COUNT(*) FROM test").Scan(&count)
+		require.NoError(t, err)
+		require.Equal(t, 0, count)
+
+		storeReplicaDB, err := store.GetReplicaDB()
+		require.NoError(t, err)
+		require.NotNil(t, storeReplicaDB)
+
+		var id int
+		err = storeReplicaDB.QueryRow("SELECT id FROM test").Scan(&id)
+		require.NoError(t, err)
+		require.Equal(t, 3, id)
+
 		require.NoError(t, store.Close())
 	})
 }

--- a/system_test.go
+++ b/system_test.go
@@ -39,7 +39,7 @@ func TestGetManifest(t *testing.T) {
 		api := &plugintest.API{}
 		api.On("GetBundlePath").Return(dir, nil)
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 		m, err := client.System.GetManifest()
 		require.NoError(t, err)
 		require.Equal(t, expectedManifest, m)
@@ -56,7 +56,7 @@ func TestGetManifest(t *testing.T) {
 		api := &plugintest.API{}
 		api.On("GetBundlePath").Return("", errors.New(""))
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 		m, err := client.System.GetManifest()
 		require.Error(t, err)
 		require.Nil(t, m)
@@ -70,7 +70,7 @@ func TestGetManifest(t *testing.T) {
 		api := &plugintest.API{}
 		api.On("GetBundlePath").Return(dir, nil)
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 		m, err := client.System.GetManifest()
 		require.Error(t, err)
 		require.Nil(t, m)
@@ -81,7 +81,7 @@ func TestRequestTrialLicense(t *testing.T) {
 	t.Run("Server version incompatible", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetServerVersion").Return("5.35.0")
 		err := client.System.RequestTrialLicense("requesterID", 10, true, true)
@@ -93,7 +93,7 @@ func TestRequestTrialLicense(t *testing.T) {
 	t.Run("Server version compatible", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetServerVersion").Return("5.36.0")
 		api.On("RequestTrialLicense", "requesterID", 10, true, true).Return(nil)

--- a/team_test.go
+++ b/team_test.go
@@ -17,7 +17,7 @@ func TestCreateTeam(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("CreateTeam", &model.Team{Name: "1"}).Return(&model.Team{Name: "1", Id: "2"}, nil)
 
@@ -30,7 +30,7 @@ func TestCreateTeam(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 
@@ -47,7 +47,7 @@ func TestGetTeam(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetTeam", "1").Return(&model.Team{Id: "2"}, nil)
 
@@ -60,7 +60,7 @@ func TestGetTeam(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
 
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 
@@ -76,7 +76,7 @@ func TestGetTeamByName(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetTeamByName", "1").Return(&model.Team{Id: "2"}, nil)
 
@@ -88,7 +88,7 @@ func TestGetTeamByName(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 
@@ -104,7 +104,7 @@ func TestUpdateTeam(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("UpdateTeam", &model.Team{Name: "1"}).Return(&model.Team{Name: "1", Id: "2"}, nil)
 
@@ -117,7 +117,7 @@ func TestUpdateTeam(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 
@@ -134,7 +134,7 @@ func TestListTeams(t *testing.T) {
 	t.Run("list all", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetTeams").Return([]*model.Team{{Id: "1"}, {Id: "2"}}, nil)
 
@@ -146,7 +146,7 @@ func TestListTeams(t *testing.T) {
 	t.Run("list scoped to user", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetTeamsForUser", "3").Return([]*model.Team{{Id: "1"}, {Id: "2"}}, nil)
 
@@ -158,7 +158,7 @@ func TestListTeams(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 
@@ -174,7 +174,7 @@ func TestSearchTeams(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("SearchTeams", "1").Return([]*model.Team{{Id: "1"}, {Id: "2"}}, nil)
 
@@ -186,7 +186,7 @@ func TestSearchTeams(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 
@@ -202,7 +202,7 @@ func TestDeleteTeam(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("DeleteTeam", "1").Return(nil)
 
@@ -213,7 +213,7 @@ func TestDeleteTeam(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 
@@ -228,7 +228,7 @@ func TestGetTeamIcon(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetTeamIcon", "1").Return([]byte{2}, nil)
 
@@ -242,7 +242,7 @@ func TestGetTeamIcon(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 
@@ -258,7 +258,7 @@ func TestSetIcon(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("SetTeamIcon", "1", []byte{2}).Return(nil)
 
@@ -269,7 +269,7 @@ func TestSetIcon(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 
@@ -284,7 +284,7 @@ func TestDeleteIcon(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("RemoveTeamIcon", "1").Return(nil)
 
@@ -295,7 +295,7 @@ func TestDeleteIcon(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 
@@ -310,7 +310,7 @@ func TestGetTeamUsers(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetUsersInTeam", "1", 2, 3).Return([]*model.User{{Id: "1"}, {Id: "2"}}, nil)
 
@@ -322,7 +322,7 @@ func TestGetTeamUsers(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 
@@ -339,7 +339,7 @@ func TestGetTeamUnreads(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
 
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetTeamsUnreadForUser", "1").Return([]*model.TeamUnread{{TeamId: "1"}, {TeamId: "2"}}, nil)
 
@@ -351,7 +351,7 @@ func TestGetTeamUnreads(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 
@@ -367,7 +367,7 @@ func TestCreateTeamMember(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("CreateTeamMember", "1", "2").Return(&model.TeamMember{TeamId: "3"}, nil)
 
@@ -380,7 +380,7 @@ func TestCreateTeamMember(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
 
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 
@@ -396,7 +396,7 @@ func TestCreateTeamMembers(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("CreateTeamMembers", "1", []string{"2"}, "3").Return([]*model.TeamMember{{TeamId: "4"}, {TeamId: "5"}}, nil)
 
@@ -408,7 +408,7 @@ func TestCreateTeamMembers(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 
@@ -424,7 +424,7 @@ func TestGetTeamMember(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetTeamMember", "1", "2").Return(&model.TeamMember{TeamId: "3"}, nil)
 
@@ -436,7 +436,7 @@ func TestGetTeamMember(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 
@@ -452,7 +452,7 @@ func TestGetTeamMembers(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetTeamMembers", "1", 2, 3).Return([]*model.TeamMember{{TeamId: "4"}, {TeamId: "5"}}, nil)
 
@@ -464,7 +464,7 @@ func TestGetTeamMembers(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 
@@ -480,7 +480,7 @@ func TestGetUserMemberships(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetTeamMembersForUser", "1", 2, 3).Return([]*model.TeamMember{{TeamId: "4"}, {TeamId: "5"}}, nil)
 
@@ -492,7 +492,7 @@ func TestGetUserMemberships(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 
@@ -508,7 +508,7 @@ func TestUpdateTeamMemberRoles(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("UpdateTeamMemberRoles", "1", "2", "3").Return(&model.TeamMember{TeamId: "3"}, nil)
 
@@ -520,7 +520,7 @@ func TestUpdateTeamMemberRoles(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 
@@ -536,7 +536,7 @@ func TestDeleteTeamMember(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("DeleteTeamMember", "1", "2", "3").Return(nil)
 
@@ -547,7 +547,7 @@ func TestDeleteTeamMember(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 
@@ -562,7 +562,7 @@ func TestGetTeamStats(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		api.On("GetTeamStats", "1").Return(&model.TeamStats{TeamId: "3"}, nil)
 
@@ -574,7 +574,7 @@ func TestGetTeamStats(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		appErr := model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError)
 

--- a/user_test.go
+++ b/user_test.go
@@ -15,7 +15,7 @@ func TestCreateUser(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		expectedUser := &model.User{
 			Username: "test",
@@ -29,7 +29,7 @@ func TestCreateUser(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		expectedUser := &model.User{
 			Username: "test",
@@ -45,7 +45,7 @@ func TestDeleteUser(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		expectedUserID := model.NewId()
 		api.On("DeleteUser", expectedUserID).Return(nil)
@@ -57,7 +57,7 @@ func TestDeleteUser(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		expectedUserID := model.NewId()
 		api.On("DeleteUser", expectedUserID).Return(newAppError())
@@ -71,7 +71,7 @@ func TestGetUsers(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		options := &model.UserGetOptions{}
 		expectedUsers := []*model.User{{Username: "test"}}
@@ -85,7 +85,7 @@ func TestGetUsers(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		options := &model.UserGetOptions{}
 		api.On("GetUsers", options).Return(nil, newAppError())
@@ -100,7 +100,7 @@ func TestGetUser(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		userID := "id"
 		expectedUser := &model.User{Id: userID, Username: "test"}
@@ -114,7 +114,7 @@ func TestGetUser(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		userID := "id"
 		api.On("GetUser", userID).Return(nil, newAppError())
@@ -129,7 +129,7 @@ func TestGetUserByEmail(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		email := "test@example.com"
 		expectedUser := &model.User{Email: email, Username: "test"}
@@ -143,7 +143,7 @@ func TestGetUserByEmail(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		email := "test@example.com"
 		api.On("GetUserByEmail", email).Return(nil, newAppError())
@@ -158,7 +158,7 @@ func TestGetUserByUsername(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		username := "test"
 		expectedUser := &model.User{Username: username}
@@ -172,7 +172,7 @@ func TestGetUserByUsername(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		username := "test"
 		api.On("GetUserByUsername", username).Return(nil, newAppError())
@@ -187,7 +187,7 @@ func TestGetUsersByUsernames(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		usernames := []string{"test1", "test2"}
 		expectedUsers := []*model.User{{Username: "test1"}, {Username: "test2"}}
@@ -201,7 +201,7 @@ func TestGetUsersByUsernames(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		usernames := []string{"test1", "test2"}
 		api.On("GetUsersByUsernames", usernames).Return(nil, newAppError())
@@ -216,7 +216,7 @@ func TestGetUsersInTeam(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		teamID := "team_id"
 		page := 1
@@ -232,7 +232,7 @@ func TestGetUsersInTeam(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		api := &plugintest.API{}
 		defer api.AssertExpectations(t)
-		client := pluginapi.NewClient(api, &plugintest.Driver{})
+		client := pluginapi.NewClient(api)
 
 		teamID := "team_id"
 		page := 1
@@ -248,7 +248,7 @@ func TestGetUsersInTeam(t *testing.T) {
 func TestHasTeamUserPermission(t *testing.T) {
 	api := &plugintest.API{}
 	defer api.AssertExpectations(t)
-	client := pluginapi.NewClient(api, &plugintest.Driver{})
+	client := pluginapi.NewClient(api)
 
 	api.On("HasPermissionToTeam", "1", "2", &model.Permission{Id: "3"}).Return(true)
 


### PR DESCRIPTION
#### Summary
- Reverts #93 so that IC plugin can revert its DB RPC API change, see thread: https://community-daily.mattermost.com/private-core/pl/7ag51xd7q7dxpy1hqqjax38ofo

