### PR TITLE
[MM-37970] Update to mattermost-server/v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A hackathon project to explore reworking the Mattermost Plugin API.
 
-The plugin API as exposed in [github.com/mattermost/mattermost-server/plugin](http://github.com/mattermost/mattermost-server/blob/master/plugin/api.go) began with the hope of adopting a consistent interface and style. But our vision for how to structure the API changed over time, along with our ability to remain consistent. 
+The plugin API as exposed in [github.com/mattermost/mattermost-server/plugin](http://github.com/mattermost/mattermost-server/blob/master/plugin/api.go) began with the hope of adopting a consistent interface and style. But our vision for how to structure the API changed over time, along with our ability to remain consistent.
 
 Fixing the API in place is difficult. Any backwards incompatible changes to the RPC API would break existing plugins. Even backwards incompatible changes to the plugin helpers would break semver, requiring a coordinated major version bump with parent repository. Adding new methods improves the experience for newer plugins, but forever clutters the [plugin GoDoc](https://godoc.org/github.com/mattermost/mattermost-server/plugin).
 
@@ -23,11 +23,11 @@ Usage of this package is altogether optional, allowing plugin authors to switch 
 
 ## Getting Started
 
-This package is in a pre-alpha state. To start using this API with your own plugin, first change all your import statements to reference the newly moduled `v5` version of the Mattermost server:
+This package is in a pre-alpha state. To start using this API with your own plugin, first change all your import statements to reference the newly moduled `v6` version of the Mattermost server:
 ```diff
 import (
 -    "github.com/mattermost/mattermost-server"
-+    "github.com/mattermost/mattermost-server/v5"
++    "github.com/mattermost/mattermost-server/v6"
 )
 ```
 

--- a/bot.go
+++ b/bot.go
@@ -1,12 +1,8 @@
 package pluginapi
 
 import (
-	"bytes"
-	"io"
-	"io/ioutil"
-
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 )
 
 const (
@@ -106,37 +102,4 @@ func (b *BotService) UpdateActive(botUserID string, isActive bool) (*model.Bot, 
 // Minimum server version: 5.10
 func (b *BotService) DeletePermanently(botUserID string) error {
 	return normalizeAppErr(b.api.PermanentDeleteBot(botUserID))
-}
-
-// GetIconImage gets the bot icon image shown for the bot in the LHS.
-//
-// Minimum server version: 5.14
-func (b *BotService) GetIconImage(botUserID string) (io.Reader, error) {
-	contentBytes, appErr := b.api.GetBotIconImage(botUserID)
-	if appErr != nil {
-		return nil, normalizeAppErr(appErr)
-	}
-
-	return bytes.NewReader(contentBytes), nil
-}
-
-// SetIconImage sets the bot icon image to be shown in the LHS.
-//
-// Icon image must be SVG format, as all other formats are rejected.
-//
-// Minimum server version: 5.14
-func (b *BotService) SetIconImage(botUserID string, content io.Reader) error {
-	contentBytes, err := ioutil.ReadAll(content)
-	if err != nil {
-		return err
-	}
-
-	return normalizeAppErr(b.api.SetBotIconImage(botUserID, contentBytes))
-}
-
-// DeleteIconImage deletes the bot icon image shown for the bot in the LHS.
-//
-// Minimum server version: 5.14
-func (b *BotService) DeleteIconImage(botUserID string) error {
-	return normalizeAppErr(b.api.DeleteBotIconImage(botUserID))
 }

--- a/channel.go
+++ b/channel.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 	"github.com/pkg/errors"
 )
 
@@ -275,14 +275,10 @@ func (c *ChannelService) waitForChannelCreation(channelID string) error {
 	return errors.Errorf("giving up waiting for channel creation, channelID=%s", channelID)
 }
 
-func channelMembersToChannelMemberSlice(cm *model.ChannelMembers) []*model.ChannelMember {
-	if cm == nil {
-		return nil
-	}
-
-	cmp := make([]*model.ChannelMember, len(*cm))
-	for i := 0; i < len(*cm); i++ {
-		cmp[i] = &(*cm)[i]
+func channelMembersToChannelMemberSlice(cm model.ChannelMembers) []*model.ChannelMember {
+	cmp := make([]*model.ChannelMember, len(cm))
+	for i := 0; i < len(cm); i++ {
+		cmp[i] = &(cm)[i]
 	}
 
 	return cmp

--- a/channel_test.go
+++ b/channel_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
 	"github.com/stretchr/testify/require"
 
 	pluginapi "github.com/mattermost/mattermost-plugin-api"

--- a/client.go
+++ b/client.go
@@ -2,7 +2,7 @@ package pluginapi
 
 import (
 	"github.com/blang/semver/v4"
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 	"github.com/pkg/errors"
 )
 

--- a/cluster/job.go
+++ b/cluster/job.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
 )
 

--- a/cluster/job_example_test.go
+++ b/cluster/job_example_test.go
@@ -3,7 +3,7 @@ package cluster
 import (
 	"time"
 
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 )
 
 func ExampleSchedule() {

--- a/cluster/job_once.go
+++ b/cluster/job_once.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
 
 	pluginapi "github.com/mattermost/mattermost-plugin-api"

--- a/cluster/job_once_example_test.go
+++ b/cluster/job_once_example_test.go
@@ -3,7 +3,7 @@ package cluster
 import (
 	"time"
 
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 )
 
 func HandleJobOnceCalls(key string) {

--- a/cluster/job_once_mem_test.go
+++ b/cluster/job_once_mem_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/cluster/job_once_test.go
+++ b/cluster/job_once_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/cluster/job_test.go
+++ b/cluster/job_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/cluster/mock_plugin_api_test.go
+++ b/cluster/mock_plugin_api_test.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 )
 
 type mockPluginAPI struct {

--- a/cluster/mutex.go
+++ b/cluster/mutex.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
 )
 

--- a/cluster/mutex_example_test.go
+++ b/cluster/mutex_example_test.go
@@ -3,7 +3,7 @@ package cluster_test
 import (
 	"github.com/mattermost/mattermost-plugin-api/cluster"
 
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 )
 
 func ExampleMutex() {

--- a/cluster/mutex_test.go
+++ b/cluster/mutex_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/configuration.go
+++ b/configuration.go
@@ -1,9 +1,12 @@
 package pluginapi
 
 import (
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin"
-	"github.com/mattermost/mattermost-server/v5/utils"
+	"bytes"
+	"encoding/json"
+
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
+	"github.com/mattermost/mattermost-server/v6/utils"
 	"github.com/pkg/errors"
 )
 
@@ -73,7 +76,17 @@ func (c *ConfigurationService) CheckRequiredServerConfiguration(req *model.Confi
 	}
 
 	mergedCfg := mc.(model.Config)
-	if mergedCfg.ToJson() != cfg.ToJson() {
+	mergedCfgJSON, err := json.Marshal(mergedCfg)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to marshal merged config")
+	}
+
+	cjfJSON, err := json.Marshal(cfg)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to marshal config")
+	}
+
+	if !bytes.Equal(mergedCfgJSON, cjfJSON) {
 		return false, nil
 	}
 

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -3,8 +3,8 @@ package pluginapi_test
 import (
 	"testing"
 
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
 	"github.com/stretchr/testify/assert"
 
 	pluginapi "github.com/mattermost/mattermost-plugin-api"

--- a/email.go
+++ b/email.go
@@ -1,7 +1,7 @@
 package pluginapi
 
 import (
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 )
 
 // MailService exposes methods to send email.

--- a/emoji.go
+++ b/emoji.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"io"
 
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 )
 
 // EmojiService exposes methods to manipulate emojis.

--- a/emoji_test.go
+++ b/emoji_test.go
@@ -4,8 +4,8 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
 	"github.com/stretchr/testify/require"
 
 	pluginapi "github.com/mattermost/mattermost-plugin-api"

--- a/error.go
+++ b/error.go
@@ -3,7 +3,7 @@ package pluginapi
 import (
 	"net/http"
 
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
 )
 

--- a/example_client_test.go
+++ b/example_client_test.go
@@ -3,7 +3,7 @@ package pluginapi_test
 import (
 	pluginapi "github.com/mattermost/mattermost-plugin-api"
 
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 )
 
 type Plugin struct {

--- a/experimental/bot/bot.go
+++ b/experimental/bot/bot.go
@@ -4,7 +4,7 @@
 package bot
 
 import (
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
 
 	pluginapi "github.com/mattermost/mattermost-plugin-api"

--- a/experimental/bot/mocks/mock_bot.go
+++ b/experimental/bot/mocks/mock_bot.go
@@ -6,7 +6,7 @@ package mock_bot
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	model "github.com/mattermost/mattermost-server/v5/model"
+	model "github.com/mattermost/mattermost-server/v6/model"
 	reflect "reflect"
 )
 

--- a/experimental/bot/mocks/mock_poster.go
+++ b/experimental/bot/mocks/mock_poster.go
@@ -6,7 +6,7 @@ package mock_bot
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	model "github.com/mattermost/mattermost-server/v5/model"
+	model "github.com/mattermost/mattermost-server/v6/model"
 	reflect "reflect"
 )
 

--- a/experimental/bot/poster/default_poster.go
+++ b/experimental/bot/poster/default_poster.go
@@ -3,7 +3,7 @@ package poster
 import (
 	"fmt"
 
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 )
 
 type defaultPoster struct {

--- a/experimental/bot/poster/default_poster_test.go
+++ b/experimental/bot/poster/default_poster_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
 	"github.com/stretchr/testify/assert"
 
 	pluginapi "github.com/mattermost/mattermost-plugin-api"
@@ -104,7 +104,7 @@ func TestDMWithAttachments(t *testing.T) {
 		Id:        expectedPostID,
 		UserId:    botID,
 		ChannelId: dmChannelID,
-		Type:      model.POST_SLACK_ATTACHMENT,
+		Type:      model.PostTypeSlackAttachment,
 		Props: model.StringInterface{
 			"attachments": attachments,
 		},

--- a/experimental/bot/poster/import.go
+++ b/experimental/bot/poster/import.go
@@ -1,6 +1,6 @@
 package poster
 
-import "github.com/mattermost/mattermost-server/v5/model"
+import "github.com/mattermost/mattermost-server/v6/model"
 
 // PostAPI defines the portion of the Post Service used by the poster
 type PostAPI interface {

--- a/experimental/bot/poster/mock_import/mock_postapi.go
+++ b/experimental/bot/poster/mock_import/mock_postapi.go
@@ -6,7 +6,7 @@ package mock_import
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	model "github.com/mattermost/mattermost-server/v5/model"
+	model "github.com/mattermost/mattermost-server/v6/model"
 	reflect "reflect"
 )
 

--- a/experimental/bot/poster/poster.go
+++ b/experimental/bot/poster/poster.go
@@ -4,7 +4,7 @@
 package poster
 
 import (
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 )
 
 // Poster defines an entity that can post DMs and Ephemerals and update and delete those posts

--- a/experimental/common/slack_attachments.go
+++ b/experimental/common/slack_attachments.go
@@ -3,7 +3,7 @@ package common
 import (
 	"net/http"
 
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 )
 
 func SlackAttachmentError(w http.ResponseWriter, errorMessage string) {

--- a/experimental/flow/handler.go
+++ b/experimental/flow/handler.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-api/experimental/flow/steps"
 
 	"github.com/gorilla/mux"
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 )
 
 type fh struct {

--- a/experimental/flow/mocks/mock_step.go
+++ b/experimental/flow/mocks/mock_step.go
@@ -7,7 +7,7 @@ package mock_flow
 import (
 	gomock "github.com/golang/mock/gomock"
 	freetextfetcher "github.com/mattermost/mattermost-plugin-api/experimental/freetextfetcher"
-	model "github.com/mattermost/mattermost-server/v5/model"
+	model "github.com/mattermost/mattermost-server/v6/model"
 	reflect "reflect"
 )
 

--- a/experimental/flow/steps/empty_step.go
+++ b/experimental/flow/steps/empty_step.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/mattermost/mattermost-plugin-api/experimental/freetextfetcher"
 
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 )
 
 type emptyStep struct {

--- a/experimental/flow/steps/freetext_step.go
+++ b/experimental/flow/steps/freetext_step.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-api/experimental/freetextfetcher"
 
 	"github.com/gorilla/mux"
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 )
 
 type freetextStep struct {

--- a/experimental/flow/steps/simple_step.go
+++ b/experimental/flow/steps/simple_step.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/mattermost/mattermost-plugin-api/experimental/freetextfetcher"
 
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 )
 
 type simpleStep struct {

--- a/experimental/flow/steps/step.go
+++ b/experimental/flow/steps/step.go
@@ -3,7 +3,7 @@ package steps
 import (
 	"github.com/mattermost/mattermost-plugin-api/experimental/freetextfetcher"
 
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 )
 
 const (

--- a/experimental/freetextfetcher/freetext_fetcher.go
+++ b/experimental/freetextfetcher/freetext_fetcher.go
@@ -7,8 +7,8 @@ import (
 	"github.com/mattermost/mattermost-plugin-api/experimental/bot/poster"
 
 	"github.com/gorilla/mux"
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 )
 
 // FreetextFetcher defines the behavior of free text fetchers

--- a/experimental/freetextfetcher/freetext_fetcher_manager.go
+++ b/experimental/freetextfetcher/freetext_fetcher_manager.go
@@ -3,8 +3,8 @@ package freetextfetcher
 import (
 	"github.com/mattermost/mattermost-plugin-api/experimental/bot/logger"
 
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 )
 
 // Manager defines the behavior of the freetext manager

--- a/experimental/freetextfetcher/handler.go
+++ b/experimental/freetextfetcher/handler.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-api/experimental/common"
 
 	"github.com/gorilla/mux"
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 )
 
 const (

--- a/experimental/freetextfetcher/mocks/mock_fetcher.go
+++ b/experimental/freetextfetcher/mocks/mock_fetcher.go
@@ -7,8 +7,8 @@ package mock_freetext_fetcher
 import (
 	gomock "github.com/golang/mock/gomock"
 	logger "github.com/mattermost/mattermost-plugin-api/experimental/bot/logger"
-	model "github.com/mattermost/mattermost-server/v5/model"
-	plugin "github.com/mattermost/mattermost-server/v5/plugin"
+	model "github.com/mattermost/mattermost-server/v6/model"
+	plugin "github.com/mattermost/mattermost-server/v6/plugin"
 	reflect "reflect"
 )
 

--- a/experimental/freetextfetcher/mocks/mock_manager.go
+++ b/experimental/freetextfetcher/mocks/mock_manager.go
@@ -7,8 +7,8 @@ package mock_freetext_fetcher
 import (
 	gomock "github.com/golang/mock/gomock"
 	logger "github.com/mattermost/mattermost-plugin-api/experimental/bot/logger"
-	model "github.com/mattermost/mattermost-server/v5/model"
-	plugin "github.com/mattermost/mattermost-server/v5/plugin"
+	model "github.com/mattermost/mattermost-server/v6/model"
+	plugin "github.com/mattermost/mattermost-server/v6/plugin"
 	reflect "reflect"
 )
 

--- a/experimental/oauther/oauth2_connect.go
+++ b/experimental/oauther/oauth2_connect.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 	"golang.org/x/oauth2"
 
 	pluginapi "github.com/mattermost/mattermost-plugin-api"

--- a/experimental/panel/handler.go
+++ b/experimental/panel/handler.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-api/experimental/panel/settings"
 
 	"github.com/gorilla/mux"
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 )
 
 type handler struct {

--- a/experimental/panel/mocks/mock_panel.go
+++ b/experimental/panel/mocks/mock_panel.go
@@ -6,7 +6,7 @@ package mock_panel
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	model "github.com/mattermost/mattermost-server/v5/model"
+	model "github.com/mattermost/mattermost-server/v6/model"
 	reflect "reflect"
 )
 

--- a/experimental/panel/mocks/mock_setting.go
+++ b/experimental/panel/mocks/mock_setting.go
@@ -7,7 +7,7 @@ package mock_panel
 import (
 	gomock "github.com/golang/mock/gomock"
 	freetextfetcher "github.com/mattermost/mattermost-plugin-api/experimental/freetextfetcher"
-	model "github.com/mattermost/mattermost-server/v5/model"
+	model "github.com/mattermost/mattermost-server/v6/model"
 	reflect "reflect"
 )
 

--- a/experimental/panel/panel.go
+++ b/experimental/panel/panel.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-api/experimental/common"
 	"github.com/mattermost/mattermost-plugin-api/experimental/panel/settings"
 
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 )
 
 type Panel interface {

--- a/experimental/panel/settings/bool_setting.go
+++ b/experimental/panel/settings/bool_setting.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 )
 
 type boolSetting struct {

--- a/experimental/panel/settings/empty_setting.go
+++ b/experimental/panel/settings/empty_setting.go
@@ -3,7 +3,7 @@ package settings
 import (
 	"fmt"
 
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 )
 
 type emptySetting struct {

--- a/experimental/panel/settings/freetext_setting.go
+++ b/experimental/panel/settings/freetext_setting.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-api/experimental/freetextfetcher"
 
 	"github.com/gorilla/mux"
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 )
 
 type freetextSetting struct {

--- a/experimental/panel/settings/option_setting.go
+++ b/experimental/panel/settings/option_setting.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 )
 
 type optionSetting struct {

--- a/experimental/panel/settings/read_only_setting.go
+++ b/experimental/panel/settings/read_only_setting.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 )
 
 type readOnlySetting struct {

--- a/experimental/panel/settings/setting.go
+++ b/experimental/panel/settings/setting.go
@@ -3,7 +3,7 @@ package settings
 import (
 	"github.com/mattermost/mattermost-plugin-api/experimental/freetextfetcher"
 
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 )
 
 const (

--- a/experimental/panel/settings/utils.go
+++ b/experimental/panel/settings/utils.go
@@ -1,6 +1,6 @@
 package settings
 
-import "github.com/mattermost/mattermost-server/v5/model"
+import "github.com/mattermost/mattermost-server/v6/model"
 
 func stringsToOptions(in []string) []*model.PostActionOptions {
 	out := make([]*model.PostActionOptions, len(in))

--- a/file.go
+++ b/file.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 )
 
 // FileService exposes methods to manipulate files, most often as post attachments.

--- a/file_test.go
+++ b/file_test.go
@@ -5,8 +5,8 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
 	"github.com/stretchr/testify/require"
 
 	pluginapi "github.com/mattermost/mattermost-plugin-api"

--- a/frontend.go
+++ b/frontend.go
@@ -1,8 +1,8 @@
 package pluginapi
 
 import (
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 )
 
 // FrontendService exposes methods to interact with the frontend.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang/mock v1.4.4
 	github.com/gorilla/mux v1.8.0
 	github.com/lib/pq v1.10.2
-	github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210714130822-54b0ef574b5d
+	github.com/mattermost/mattermost-server/v6 v6.0.0-20210817091833-04b27ce93c02
 	github.com/nicksnyder/go-i18n/v2 v2.0.3
 	github.com/pkg/errors v0.9.1
 	github.com/rudderlabs/analytics-go v3.3.1+incompatible

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang/mock v1.4.4
 	github.com/gorilla/mux v1.8.0
 	github.com/lib/pq v1.10.2
-	github.com/mattermost/mattermost-server/v6 v6.0.0-20210817091833-04b27ce93c02
+	github.com/mattermost/mattermost-server/v6 v6.0.0-20210819192026-ab0e82d65692
 	github.com/nicksnyder/go-i18n/v2 v2.0.3
 	github.com/pkg/errors v0.9.1
 	github.com/rudderlabs/analytics-go v3.3.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -387,7 +387,6 @@ github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b/go.mod h1:VzxiSdG6j1p
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -400,7 +399,6 @@ github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iP
 github.com/hashicorp/go-msgpack v1.1.5/go.mod h1:gWVc3sv/wbDmR3rQsj1CAktEZzoz1YNK9NfGLXJ69/4=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.4.2 h1:yFvG3ufXXpqiMiZx9HLcaK3XbIqQ1WJFR/F1a2CuVw0=
 github.com/hashicorp/go-plugin v1.4.2/go.mod h1:5fGEH17QVwTTcR0zV7yhDPLLmFX9YSZ38b18Udy6vYQ=
@@ -559,8 +557,10 @@ github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d h1:/RJ/UV7M5c7L2TQ
 github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d/go.mod h1:HLbgMEI5K131jpxGazJ97AxfPDt31osq36YS1oxFQPQ=
 github.com/mattermost/logr v1.0.13 h1:6F/fM3csvH6Oy5sUpJuW7YyZSzZZAhJm5VcgKMxA2P8=
 github.com/mattermost/logr v1.0.13/go.mod h1:Mt4DPu1NXMe6JxPdwCC0XBoxXmN9eXOIRPoZarU2PXs=
-github.com/mattermost/mattermost-server/v6 v6.0.0-20210817091833-04b27ce93c02 h1:v2SaNLiD02UAWJVwTvDBkFTqD2GwyPaRJ3vs7yDwcpE=
-github.com/mattermost/mattermost-server/v6 v6.0.0-20210817091833-04b27ce93c02/go.mod h1:lRyN5kvq4pllE0+9fGsxneaSRDszzaRISo6Z49YHg+M=
+github.com/mattermost/logr/v2 v2.0.10 h1:i6rJbuX/EkBM9maM8M0eJ3rxB+fsBKNslPvzSlA2w/M=
+github.com/mattermost/logr/v2 v2.0.10/go.mod h1:mpPp935r5dIkFDo2y9Q87cQWhFR/4xXpNh0k/y8Hmwg=
+github.com/mattermost/mattermost-server/v6 v6.0.0-20210819192026-ab0e82d65692 h1:X0AvrYQsLFOaS02jNDJgnZmkESII27F4lOV+f7RCV5A=
+github.com/mattermost/mattermost-server/v6 v6.0.0-20210819192026-ab0e82d65692/go.mod h1:+S8CsNEPv1FOl1usaPBQ6Gu9+Sm1Cc9YdU/Qh1YMGVI=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
@@ -881,7 +881,6 @@ github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49u
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
 github.com/vmihailenco/msgpack/v5 v5.3.4/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/wiggin77/cfg v1.0.2 h1:NBUX+iJRr+RTncTqTNvajHwzduqbhCQjEqxLHr6Fk7A=
 github.com/wiggin77/cfg v1.0.2/go.mod h1:b3gotba2e5bXTqTW48DwIFoLc+4lWKP7WPi/CdvZ4aE=
 github.com/wiggin77/merror v1.0.2/go.mod h1:uQTcIU0Z6jRK4OwqganPYerzQxSFJ4GSHM3aurxxQpg=
 github.com/wiggin77/merror v1.0.3 h1:8+ZHV+aSnJoYghE3EUThl15C6rvF2TYRSvOSBjdmNR8=
@@ -940,15 +939,12 @@ go.opentelemetry.io/otel/trace v1.0.0-RC1/go.mod h1:86UHmyHWFEtWjfWPSbu0+d0Pf9Q6
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-go.uber.org/atomic v1.8.0 h1:CUhrE4N1rqSE6FM9ecihEjRkLQu8cDfgDyoOs83mEY4=
 go.uber.org/atomic v1.8.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
-go.uber.org/multierr v1.7.0 h1:zaiO/rmgFjbmCXdSYJWQcdvOCsthmdaHfr3Gm2Kx4Ec=
 go.uber.org/multierr v1.7.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
-go.uber.org/zap v1.17.0 h1:MTjgFu6ZLKvY6Pvaqk97GlxNBuMpV4Hy/3P6tRGlI2U=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 golang.org/x/build v0.0.0-20190111050920-041ab4dc3f9d/go.mod h1:OWs+y06UdEOHN4y+MfF/py+xQ/tYqIWW03b70/CG9Rw=

--- a/go.sum
+++ b/go.sum
@@ -36,7 +36,7 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
-code.sajari.com/docconv v1.1.1-0.20200701232649-d9ea05fbd50a/go.mod h1:DooS873W9YwUjTwEYGpg55aDlvnx1VcEdr7IJ9rEW8g=
+code.sajari.com/docconv v1.1.1-0.20210427001343-7b3472bc323a/go.mod h1:KPNt2zuWplps1W0TpOb6ltHj4Xu+j6h7a+YkqGHrxQE=
 contrib.go.opencensus.io/exporter/ocagent v0.4.9/go.mod h1:ueLzZcP7LPhPulEBukGn4aLh7Mx9YJwpVJ9nL2FYltw=
 dmitri.shuralyov.com/app/changes v0.0.0-20180602232624-0a106ad413e3/go.mod h1:Yl+fi1br7+Rr3LqpNJf1/uxUdtRUV+Tnj0o93V2B9MU=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
@@ -552,15 +552,15 @@ github.com/markbates/pkger v0.15.1/go.mod h1:0JoVlrol20BSywW79rN3kdFFsE5xYM+rSCQ
 github.com/marstr/guid v0.0.0-20170427235115-8bdf7d1a087c/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
 github.com/mattermost/go-i18n v1.11.0 h1:1hLKqn/ZvhZ80OekjVPGYcCrBfMz+YxNNgqS+beL7zE=
 github.com/mattermost/go-i18n v1.11.0/go.mod h1:RyS7FDNQlzF1PsjbJWHRI35exqaKGSO9qD4iv8QjE34=
-github.com/mattermost/gorp v1.6.2-0.20210419141818-0904a6a388d3/go.mod h1:QCQ3U0M9T/BlAdjKFJo0I1oe/YAgbyjNdhU8bpOLafk=
+github.com/mattermost/gorp v1.6.2-0.20210714143452-8b50f5209a7f/go.mod h1:QCQ3U0M9T/BlAdjKFJo0I1oe/YAgbyjNdhU8bpOLafk=
 github.com/mattermost/gosaml2 v0.3.3/go.mod h1:Z429EIOiEi9kbq6yHoApfzlcXpa6dzRDc6pO+Vy2Ksk=
 github.com/mattermost/gziphandler v0.0.1/go.mod h1:CvvZR7sXqhj81V2swXuQY7T04Ccc89u7W7pHNPKev8g=
 github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d h1:/RJ/UV7M5c7L2TQ0KNm4yZxxFvC1nvRz/gY/Daa35aI=
 github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d/go.mod h1:HLbgMEI5K131jpxGazJ97AxfPDt31osq36YS1oxFQPQ=
 github.com/mattermost/logr v1.0.13 h1:6F/fM3csvH6Oy5sUpJuW7YyZSzZZAhJm5VcgKMxA2P8=
 github.com/mattermost/logr v1.0.13/go.mod h1:Mt4DPu1NXMe6JxPdwCC0XBoxXmN9eXOIRPoZarU2PXs=
-github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210714130822-54b0ef574b5d h1:Wi0JxTkVOqT6reoM9SjGXRe+i9HmKlfq+vnk2l7C3DI=
-github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210714130822-54b0ef574b5d/go.mod h1:612+SrZlf9+6RAgjGouAdpLrqcctSzjIT6YlJBWcfVk=
+github.com/mattermost/mattermost-server/v6 v6.0.0-20210817091833-04b27ce93c02 h1:v2SaNLiD02UAWJVwTvDBkFTqD2GwyPaRJ3vs7yDwcpE=
+github.com/mattermost/mattermost-server/v6 v6.0.0-20210817091833-04b27ce93c02/go.mod h1:lRyN5kvq4pllE0+9fGsxneaSRDszzaRISo6Z49YHg+M=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=

--- a/group.go
+++ b/group.go
@@ -1,8 +1,8 @@
 package pluginapi
 
 import (
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 )
 
 // GroupService exposes methods to manipulate groups.

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/nicksnyder/go-i18n/v2/i18n"
 	"github.com/pkg/errors"
 	"golang.org/x/text/language"

--- a/i18n/i18n_test.go
+++ b/i18n/i18n_test.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin"
-	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
+	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/kv.go
+++ b/kv.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 	"github.com/pkg/errors"
 )
 

--- a/kv_test.go
+++ b/kv_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/license.go
+++ b/license.go
@@ -1,7 +1,7 @@
 package pluginapi
 
 import (
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 )
 
 const (

--- a/license_test.go
+++ b/license_test.go
@@ -3,7 +3,7 @@ package pluginapi
 import (
 	"testing"
 
-	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/log.go
+++ b/log.go
@@ -1,7 +1,7 @@
 package pluginapi
 
 import (
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 )
 
 // LogService exposes methods to log to the Mattermost server log.

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -3,7 +3,7 @@ package pluginapi_test
 import (
 	"testing"
 
-	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
+	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 

--- a/oauth.go
+++ b/oauth.go
@@ -1,8 +1,8 @@
 package pluginapi
 
 import (
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 )
 
 // UserService exposes methods to manipulate OAuth Apps.

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
-	"github.com/mattermost/mattermost-server/v5/plugin/plugintest/mock"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
+	"github.com/mattermost/mattermost-server/v6/plugin/plugintest/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/plugins.go
+++ b/plugins.go
@@ -6,8 +6,8 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 	"github.com/pkg/errors"
 )
 

--- a/post.go
+++ b/post.go
@@ -1,8 +1,8 @@
 package pluginapi
 
 import (
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 	"github.com/pkg/errors"
 )
 

--- a/post_test.go
+++ b/post_test.go
@@ -4,9 +4,9 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin"
-	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
+	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -514,7 +514,7 @@ func TestShouldProcessMessage(t *testing.T) {
 		client := pluginapi.NewClient(api, &plugintest.Driver{})
 
 		shouldProcessMessage, err := client.Post.ShouldProcessMessage(
-			&model.Post{Type: model.POST_HEADER_CHANGE, UserId: expectedBotID},
+			&model.Post{Type: model.PostTypeHeaderChange, UserId: expectedBotID},
 			pluginapi.AllowSystemMessages(),
 			pluginapi.AllowBots(),
 		)
@@ -529,7 +529,7 @@ func TestShouldProcessMessage(t *testing.T) {
 		client := pluginapi.NewClient(api, &plugintest.Driver{})
 
 		shouldProcessMessage, err := client.Post.ShouldProcessMessage(
-			&model.Post{Type: model.POST_HEADER_CHANGE},
+			&model.Post{Type: model.PostTypeHeaderChange},
 		)
 
 		assert.NoError(t, err)
@@ -539,7 +539,7 @@ func TestShouldProcessMessage(t *testing.T) {
 	t.Run("should not process as the post is sent to another channel", func(t *testing.T) {
 		channelID := "channel-id"
 		api := setupAPI()
-		api.On("GetChannel", channelID).Return(&model.Channel{Id: channelID, Type: model.CHANNEL_GROUP}, nil)
+		api.On("GetChannel", channelID).Return(&model.Channel{Id: channelID, Type: model.ChannelTypeGroup}, nil)
 		api.On("KVGet", plugin.BotUserKey).Return([]byte(expectedBotID), nil)
 		client := pluginapi.NewClient(api, &plugintest.Driver{})
 
@@ -576,7 +576,7 @@ func TestShouldProcessMessage(t *testing.T) {
 		channelID := "1"
 		channel := model.Channel{
 			Name: "user1__" + expectedBotID,
-			Type: model.CHANNEL_OPEN,
+			Type: model.ChannelTypeOpen,
 		}
 		api := setupAPI()
 		api.On("GetChannel", channelID).Return(&channel, nil)
@@ -601,7 +601,7 @@ func TestShouldProcessMessage(t *testing.T) {
 		client := pluginapi.NewClient(api, &plugintest.Driver{})
 
 		shouldProcessMessage, err := client.Post.ShouldProcessMessage(
-			&model.Post{UserId: "1", Type: model.POST_HEADER_CHANGE, ChannelId: channelID},
+			&model.Post{UserId: "1", Type: model.PostTypeHeaderChange, ChannelId: channelID},
 			pluginapi.AllowSystemMessages(),
 			pluginapi.FilterChannelIDs([]string{channelID}),
 			pluginapi.AllowBots(),
@@ -619,7 +619,7 @@ func TestShouldProcessMessage(t *testing.T) {
 		client := pluginapi.NewClient(api, &plugintest.Driver{})
 
 		shouldProcessMessage, err := client.Post.ShouldProcessMessage(
-			&model.Post{UserId: "1", Type: model.POST_HEADER_CHANGE, ChannelId: channelID},
+			&model.Post{UserId: "1", Type: model.PostTypeHeaderChange, ChannelId: channelID},
 			pluginapi.AllowSystemMessages(),
 			pluginapi.FilterChannelIDs([]string{channelID}),
 			pluginapi.AllowBots(),
@@ -635,14 +635,14 @@ func TestShouldProcessMessage(t *testing.T) {
 		api := setupAPI()
 		channel := model.Channel{
 			Name: "user1__" + expectedBotID,
-			Type: model.CHANNEL_DIRECT,
+			Type: model.ChannelTypeDirect,
 		}
 		api.On("GetChannel", channelID).Return(&channel, nil)
 		api.On("KVGet", plugin.BotUserKey).Return([]byte(expectedBotID), nil)
 		client := pluginapi.NewClient(api, &plugintest.Driver{})
 
 		shouldProcessMessage, err := client.Post.ShouldProcessMessage(
-			&model.Post{UserId: "1", Type: model.POST_HEADER_CHANGE, ChannelId: channelID},
+			&model.Post{UserId: "1", Type: model.PostTypeHeaderChange, ChannelId: channelID},
 			pluginapi.AllowSystemMessages(),
 			pluginapi.AllowBots(),
 		)
@@ -654,7 +654,7 @@ func TestShouldProcessMessage(t *testing.T) {
 	t.Run("should not process the message which have from_webhook", func(t *testing.T) {
 		channelID := "1"
 		api := setupAPI()
-		api.On("GetChannel", channelID).Return(&model.Channel{Id: channelID, Type: model.CHANNEL_GROUP}, nil)
+		api.On("GetChannel", channelID).Return(&model.Channel{Id: channelID, Type: model.ChannelTypeGroup}, nil)
 
 		api.On("KVGet", plugin.BotUserKey).Return([]byte(expectedBotID), nil)
 
@@ -671,7 +671,7 @@ func TestShouldProcessMessage(t *testing.T) {
 	t.Run("should process the message which have from_webhook with allow webhook plugin", func(t *testing.T) {
 		channelID := "1"
 		api := setupAPI()
-		api.On("GetChannel", channelID).Return(&model.Channel{Id: channelID, Type: model.CHANNEL_GROUP}, nil)
+		api.On("GetChannel", channelID).Return(&model.Channel{Id: channelID, Type: model.ChannelTypeGroup}, nil)
 
 		api.On("KVGet", plugin.BotUserKey).Return([]byte(expectedBotID), nil)
 		client := pluginapi.NewClient(api, &plugintest.Driver{})
@@ -689,7 +689,7 @@ func TestShouldProcessMessage(t *testing.T) {
 	t.Run("should process the message where from_webhook is not set", func(t *testing.T) {
 		channelID := "1"
 		api := setupAPI()
-		api.On("GetChannel", channelID).Return(&model.Channel{Id: channelID, Type: model.CHANNEL_GROUP}, nil)
+		api.On("GetChannel", channelID).Return(&model.Channel{Id: channelID, Type: model.ChannelTypeGroup}, nil)
 
 		api.On("KVGet", plugin.BotUserKey).Return([]byte(expectedBotID), nil)
 		client := pluginapi.NewClient(api, &plugintest.Driver{})
@@ -706,7 +706,7 @@ func TestShouldProcessMessage(t *testing.T) {
 	t.Run("should process the message which have from_webhook false", func(t *testing.T) {
 		channelID := "1"
 		api := setupAPI()
-		api.On("GetChannel", channelID).Return(&model.Channel{Id: channelID, Type: model.CHANNEL_GROUP}, nil)
+		api.On("GetChannel", channelID).Return(&model.Channel{Id: channelID, Type: model.ChannelTypeGroup}, nil)
 
 		api.On("KVGet", plugin.BotUserKey).Return([]byte(expectedBotID), nil)
 		client := pluginapi.NewClient(api, &plugintest.Driver{})
@@ -724,7 +724,7 @@ func TestShouldProcessMessage(t *testing.T) {
 		userID := "user-id"
 		channelID := "1"
 		api := setupAPI()
-		api.On("GetChannel", channelID).Return(&model.Channel{Id: channelID, Type: model.CHANNEL_GROUP}, nil)
+		api.On("GetChannel", channelID).Return(&model.Channel{Id: channelID, Type: model.ChannelTypeGroup}, nil)
 
 		api.On("GetUser", userID).Return(&model.User{IsBot: false}, nil)
 

--- a/session.go
+++ b/session.go
@@ -1,8 +1,8 @@
 package pluginapi
 
 import (
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 )
 
 // SessionService exposes methods to manipulate groups.

--- a/slashcommand.go
+++ b/slashcommand.go
@@ -1,8 +1,8 @@
 package pluginapi
 
 import (
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 )
 
 // SlashCommandService exposes methods to manipulate slash commands.

--- a/store.go
+++ b/store.go
@@ -8,8 +8,8 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
 
-	"github.com/mattermost/mattermost-server/v5/plugin"
-	"github.com/mattermost/mattermost-server/v5/shared/driver"
+	"github.com/mattermost/mattermost-server/v6/plugin"
+	"github.com/mattermost/mattermost-server/v6/shared/driver"
 	"github.com/pkg/errors"
 )
 

--- a/store_test.go
+++ b/store_test.go
@@ -5,8 +5,8 @@ import (
 
 	pluginapi "github.com/mattermost/mattermost-plugin-api"
 
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
 
 	"github.com/stretchr/testify/require"
 )

--- a/system.go
+++ b/system.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 	"github.com/pkg/errors"
 )
 

--- a/system_test.go
+++ b/system_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 

--- a/team.go
+++ b/team.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 )
 
 // TeamService exposes methods to manipulate teams and their members.

--- a/team_test.go
+++ b/team_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
 	"github.com/stretchr/testify/require"
 
 	pluginapi "github.com/mattermost/mattermost-plugin-api"

--- a/user.go
+++ b/user.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 )
 
 // UserService exposes methods to manipulate users.

--- a/user_test.go
+++ b/user_test.go
@@ -3,8 +3,8 @@ package pluginapi_test
 import (
 	"testing"
 
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 


### PR DESCRIPTION
#### Summary
This PR updates the dependencies to use `mattermost-server/v6`.

I didn't update the dependency name as the project is in pre-v1 stage and breaking changes happen anyway.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37970

