### PR TITLE
Migrate away from using io/ioutil

### DIFF
--- a/bot_test.go
+++ b/bot_test.go
@@ -1,7 +1,7 @@
 package pluginapi_test
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/mattermost/mattermost-server/v6/model"
@@ -312,11 +312,11 @@ func TestEnsureBot(t *testing.T) {
 
 			expectedBotID := model.NewId()
 
-			profileImageFile, err := ioutil.TempFile("", "profile_image")
+			profileImageFile, err := os.CreateTemp("", "profile_image")
 			require.NoError(t, err)
 
 			profileImageBytes := []byte("profile image")
-			err = ioutil.WriteFile(profileImageFile.Name(), profileImageBytes, 0600)
+			err = os.WriteFile(profileImageFile.Name(), profileImageBytes, 0600)
 			require.NoError(t, err)
 
 			api.On("KVGet", plugin.BotUserKey).Return([]byte(expectedBotID), nil)
@@ -344,18 +344,18 @@ func TestEnsureBot(t *testing.T) {
 			expectedBotDisplayName := "Updated Test Bot"
 			expectedBotDescription := "updated testbotdescription"
 
-			profileImageFile, err := ioutil.TempFile("", "profile_image")
+			profileImageFile, err := os.CreateTemp("", "profile_image")
 			require.NoError(t, err)
 
 			profileImageBytes := []byte("profile image")
-			err = ioutil.WriteFile(profileImageFile.Name(), profileImageBytes, 0600)
+			err = os.WriteFile(profileImageFile.Name(), profileImageBytes, 0600)
 			require.NoError(t, err)
 
-			iconImageFile, err := ioutil.TempFile("", "profile_image")
+			iconImageFile, err := os.CreateTemp("", "profile_image")
 			require.NoError(t, err)
 
 			iconImageBytes := []byte("icon image")
-			err = ioutil.WriteFile(iconImageFile.Name(), iconImageBytes, 0600)
+			err = os.WriteFile(iconImageFile.Name(), iconImageBytes, 0600)
 			require.NoError(t, err)
 
 			api.On("GetServerVersion").Return("5.10.0")
@@ -465,11 +465,11 @@ func TestEnsureBot(t *testing.T) {
 
 			expectedBotID := model.NewId()
 
-			profileImageFile, err := ioutil.TempFile("", "profile_image")
+			profileImageFile, err := os.CreateTemp("", "profile_image")
 			require.NoError(t, err)
 
 			profileImageBytes := []byte("profile image")
-			err = ioutil.WriteFile(profileImageFile.Name(), profileImageBytes, 0600)
+			err = os.WriteFile(profileImageFile.Name(), profileImageBytes, 0600)
 			require.NoError(t, err)
 
 			api.On("KVGet", plugin.BotUserKey).Return(nil, nil)

--- a/emoji_test.go
+++ b/emoji_test.go
@@ -1,7 +1,7 @@
 package pluginapi_test
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/mattermost/mattermost-server/v6/model"
@@ -77,7 +77,7 @@ func TestGetEmojiImage(t *testing.T) {
 
 		content, format, err := client.Emoji.GetImage("1")
 		require.NoError(t, err)
-		contentBytes, err := ioutil.ReadAll(content)
+		contentBytes, err := io.ReadAll(content)
 		require.NoError(t, err)
 		require.Equal(t, []byte{1}, contentBytes)
 		require.Equal(t, "jpg", format)

--- a/experimental/command/command.go
+++ b/experimental/command/command.go
@@ -3,7 +3,7 @@ package command
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -22,7 +22,7 @@ func GetIconData(api PluginAPI, iconPath string) (string, error) {
 		return "", errors.Wrap(err, "couldn't get bundle path")
 	}
 
-	icon, err := ioutil.ReadFile(filepath.Join(bundlePath, iconPath))
+	icon, err := os.ReadFile(filepath.Join(bundlePath, iconPath))
 	if err != nil {
 		return "", errors.Wrap(err, "failed to open icon")
 	}

--- a/file.go
+++ b/file.go
@@ -3,7 +3,6 @@ package pluginapi
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/plugin"
@@ -60,7 +59,7 @@ func (f *FileService) GetLink(id string) (string, error) {
 //
 // Minimum server version: 5.6
 func (f *FileService) Upload(content io.Reader, fileName, channelID string) (*model.FileInfo, error) {
-	contentBytes, err := ioutil.ReadAll(content)
+	contentBytes, err := io.ReadAll(content)
 	if err != nil {
 		return nil, err
 	}

--- a/file_test.go
+++ b/file_test.go
@@ -2,7 +2,7 @@ package pluginapi_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/mattermost/mattermost-server/v6/model"
@@ -22,7 +22,7 @@ func TestGetFile(t *testing.T) {
 
 		content, err := client.File.Get("1")
 		require.NoError(t, err)
-		contentBytes, err := ioutil.ReadAll(content)
+		contentBytes, err := io.ReadAll(content)
 		require.NoError(t, err)
 		require.Equal(t, []byte{2}, contentBytes)
 	})
@@ -52,7 +52,7 @@ func TestGetFileByPath(t *testing.T) {
 
 		content, err := client.File.GetByPath("1")
 		require.NoError(t, err)
-		contentBytes, err := ioutil.ReadAll(content)
+		contentBytes, err := io.ReadAll(content)
 		require.NoError(t, err)
 		require.Equal(t, []byte{2}, contentBytes)
 	})

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattermost/mattermost-plugin-api
 
-go 1.13
+go 1.16
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -2,7 +2,7 @@ package i18n
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -63,7 +63,7 @@ func InitBundle(api PluginAPI, path string) (*Bundle, error) {
 
 	i18nDir := filepath.Join(bundlePath, path)
 
-	files, err := ioutil.ReadDir(i18nDir)
+	files, err := os.ReadDir(i18nDir)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open i18n directory")
 	}

--- a/i18n/i18n_test.go
+++ b/i18n/i18n_test.go
@@ -1,7 +1,6 @@
 package i18n_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,7 +34,7 @@ func ExampleInitBundle() {
 
 func TestInitBundle(t *testing.T) {
 	t.Run("fine", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "")
+		dir, err := os.MkdirTemp("", "")
 		require.NoError(t, err)
 
 		defer os.RemoveAll(dir)
@@ -47,26 +46,26 @@ func TestInitBundle(t *testing.T) {
 
 		file := filepath.Join(i18nDir, "active.de.json")
 		content := []byte("{}")
-		err = ioutil.WriteFile(file, content, 0600)
+		err = os.WriteFile(file, content, 0600)
 		require.NoError(t, err)
 
 		// Add en translation file.
 		// InitBundle should ignore it.
 		file = filepath.Join(i18nDir, "active.en.json")
 		content = []byte("")
-		err = ioutil.WriteFile(file, content, 0600)
+		err = os.WriteFile(file, content, 0600)
 		require.NoError(t, err)
 
 		// Add json junk file
 		file = filepath.Join(i18nDir, "foo.json")
 		content = []byte("")
-		err = ioutil.WriteFile(file, content, 0600)
+		err = os.WriteFile(file, content, 0600)
 		require.NoError(t, err)
 
 		// Add active. junk file
 		file = filepath.Join(i18nDir, "active.foo")
 		content = []byte("")
-		err = ioutil.WriteFile(file, content, 0600)
+		err = os.WriteFile(file, content, 0600)
 		require.NoError(t, err)
 
 		api := &plugintest.API{}
@@ -81,7 +80,7 @@ func TestInitBundle(t *testing.T) {
 	})
 
 	t.Run("fine", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "")
+		dir, err := os.MkdirTemp("", "")
 		require.NoError(t, err)
 
 		defer os.RemoveAll(dir)
@@ -93,13 +92,13 @@ func TestInitBundle(t *testing.T) {
 
 		file := filepath.Join(i18nDir, "active.de.json")
 		content := []byte("{}")
-		err = ioutil.WriteFile(file, content, 0600)
+		err = os.WriteFile(file, content, 0600)
 		require.NoError(t, err)
 
 		// Add translation file with invalid content
 		file = filepath.Join(i18nDir, "active.es.json")
 		content = []byte("foo bar")
-		err = ioutil.WriteFile(file, content, 0600)
+		err = os.WriteFile(file, content, 0600)
 		require.NoError(t, err)
 
 		api := &plugintest.API{}

--- a/logrus.go
+++ b/logrus.go
@@ -2,7 +2,7 @@ package pluginapi
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/sirupsen/logrus"
 )
@@ -57,5 +57,5 @@ func (lh *LogrusHook) Fire(entry *logrus.Entry) error {
 func ConfigureLogrus(logger *logrus.Logger, client *Client) {
 	hook := NewLogrusHook(client.Log)
 	logger.Hooks.Add(hook)
-	logger.SetOutput(ioutil.Discard)
+	logger.SetOutput(io.Discard)
 }

--- a/system_test.go
+++ b/system_test.go
@@ -1,7 +1,6 @@
 package pluginapi_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,13 +26,13 @@ func TestGetManifest(t *testing.T) {
 			Name: "Some Name",
 		}
 
-		dir, err := ioutil.TempDir("", "")
+		dir, err := os.MkdirTemp("", "")
 		require.NoError(t, err)
 		defer os.RemoveAll(dir)
 
 		tmpfn := filepath.Join(dir, "plugin.json")
 		//nolint:gosec //only used in tests
-		err = ioutil.WriteFile(tmpfn, content, 0666)
+		err = os.WriteFile(tmpfn, content, 0666)
 		require.NoError(t, err)
 
 		api := &plugintest.API{}
@@ -63,7 +62,7 @@ func TestGetManifest(t *testing.T) {
 	})
 
 	t.Run("No manifest found", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "")
+		dir, err := os.MkdirTemp("", "")
 		require.NoError(t, err)
 		defer os.RemoveAll(dir)
 

--- a/team.go
+++ b/team.go
@@ -3,7 +3,6 @@ package pluginapi
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/plugin"
@@ -128,7 +127,7 @@ func (t *TeamService) GetIcon(teamID string) (io.Reader, error) {
 //
 // Minimum server version: 5.6
 func (t *TeamService) SetIcon(teamID string, content io.Reader) error {
-	contentBytes, err := ioutil.ReadAll(content)
+	contentBytes, err := io.ReadAll(content)
 	if err != nil {
 		return err
 	}

--- a/team_test.go
+++ b/team_test.go
@@ -2,7 +2,7 @@ package pluginapi_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -234,7 +234,7 @@ func TestGetTeamIcon(t *testing.T) {
 
 		content, err := client.Team.GetIcon("1")
 		require.NoError(t, err)
-		contentBytes, err := ioutil.ReadAll(content)
+		contentBytes, err := io.ReadAll(content)
 		require.NoError(t, err)
 		require.Equal(t, []byte{2}, contentBytes)
 	})

--- a/user.go
+++ b/user.go
@@ -3,7 +3,6 @@ package pluginapi
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/plugin"
@@ -177,7 +176,7 @@ func (u *UserService) GetProfileImage(userID string) (io.Reader, error) {
 //
 // Minimum server version: 5.6
 func (u *UserService) SetProfileImage(userID string, content io.Reader) error {
-	contentBytes, err := ioutil.ReadAll(content)
+	contentBytes, err := io.ReadAll(content)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#### Summary
`io/ioutil` is deprecated, so let's use the appropriate packages instead

#### Ticket Link
None