### PR TITLE
bot: Add a comment to bot.go about EnsureBot method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 coverage.txt
+
+.vscode
+

--- a/bot.go
+++ b/bot.go
@@ -144,6 +144,8 @@ type mutex interface {
 	Unlock()
 }
 
+// TODO: this utility function is also used by the product framework. We should move this to mattermost-server and share
+// the code to maintain consistent behavior. Ticket: MM-44953
 func (b *BotService) ensureBot(m mutex, bot *model.Bot, options ...EnsureBotOption) (string, error) {
 	err := ensureServerVersion(b.api, "5.10.0")
 	if err != nil {


### PR DESCRIPTION

#### Summary
Add a `TODO` comment to `bot.go` about moving `EnsureBot` method to mattermost-server repository.



