### PR TITLE
Improved logrus logging

### DIFF
--- a/cluster/job_once.go
+++ b/cluster/job_once.go
@@ -3,14 +3,11 @@ package cluster
 import (
 	"encoding/json"
 	"math/rand"
-	"net/http"
 	"sync"
 	"time"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
-
-	apierrors "github.com/mattermost/mattermost-plugin-api/errors"
 )
 
 const (
@@ -214,10 +211,6 @@ func addJitter() time.Duration {
 func normalizeAppErr(appErr *model.AppError) error {
 	if appErr == nil {
 		return nil
-	}
-
-	if appErr.StatusCode == http.StatusNotFound {
-		return apierrors.ErrNotFound
 	}
 
 	return appErr

--- a/error.go
+++ b/error.go
@@ -3,12 +3,15 @@ package pluginapi
 import (
 	"net/http"
 
-	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/pkg/errors"
 
-	"github.com/mattermost/mattermost-plugin-api/errors"
+	"github.com/mattermost/mattermost-server/v6/model"
 )
 
-// normalizeAppError returns a truly nil error if appErr is nil as well as normalizing a class
+// ErrNotFound is returned by the plugin API when an object is not found.
+var ErrNotFound = errors.New("not found")
+
+// normalizeAppErr returns a truly nil error if appErr is nil as well as normalizing a class
 // of non-nil AppErrors to simplify use within plugins.
 //
 // This doesn't happen automatically when a *model.AppError is cast to an error, since the
@@ -29,7 +32,7 @@ func normalizeAppErr(appErr *model.AppError) error {
 	}
 
 	if appErr.StatusCode == http.StatusNotFound {
-		return errors.ErrNotFound
+		return ErrNotFound
 	}
 
 	return appErr

--- a/errors/error.go
+++ b/errors/error.go
@@ -1,8 +1,0 @@
-package errors
-
-import (
-	"github.com/pkg/errors"
-)
-
-// ErrNotFound is returned by the plugin API when an object is not found.
-var ErrNotFound = errors.New("not found")


### PR DESCRIPTION
#### Summary
This change accompanies a Playbooks PR to improve the logging story with `logrus`:
* Set `logrus.TraceLevel` by default so that the server gets all logs and can do its own filtering. Plugins that forget to set a level end up with `logrus.InfoLevel` and have no way to programmatically enable debug logs.
* Add a `plugin_caller` field to logging events, tracing the logger from the plugin's perspective instead of having the server clobber it with a `caller` that's just `app/plugin_api.go`.

As part of this, I also eliminated the `errors` package, avoiding the circular dependency with `cluster` by just simplifying the version of `normalizeAppError` there.

#### Ticket Link
None.
