### PR TITLE
Add build info command helper

### DIFF
--- a/experimental/command/info.go
+++ b/experimental/command/info.go
@@ -1,0 +1,63 @@
+package command
+
+import (
+	"fmt"
+	"regexp"
+	"runtime/debug"
+	"strings"
+	"time"
+
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/pkg/errors"
+)
+
+func BuildInfoAutocomplete(cmd string) *model.AutocompleteData {
+	return model.NewAutocompleteData(cmd, "", "Display build info")
+}
+
+func BuildInfo(manifest model.Manifest, props map[string]any) (string, error) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "", errors.New("failed to read build info")
+	}
+
+	var (
+		revision      string
+		revisionShort string
+		buildTime     time.Time
+	)
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			revision = s.Value
+			revisionShort = revision[0:7]
+		case "vcs.time":
+			var err error
+			buildTime, err = time.Parse(time.RFC3339, s.Value)
+
+			if err != nil {
+				return "", err
+			}
+		}
+	}
+
+	path := info.Main.Path
+
+	reg, err := regexp.Compile(`/v\d$`)
+	if err != nil {
+		return "", err
+	}
+	matches := reg.FindAllString(path, -1)
+	if len(matches) > 0 {
+		path = strings.TrimSuffix(path, matches[len(matches)-1])
+	}
+
+	commit := fmt.Sprintf("[%s](https://%s/commit/%s)", revisionShort, path, revision)
+
+	var propsText string
+	for k, v := range props {
+		propsText += fmt.Sprintf(", %s: %v", k, v)
+	}
+
+	return fmt.Sprintf("%s version: %s, %s, built %s with %s%s\n", manifest.Name, manifest.Version, commit, buildTime.Format(time.RFC1123), info.GoVersion, propsText), nil
+}

--- a/experimental/command/info.go
+++ b/experimental/command/info.go
@@ -11,6 +11,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+var versionRegexp = regexp.MustCompile(`/v\d$`)
+
 func BuildInfoAutocomplete(cmd string) *model.AutocompleteData {
 	return model.NewAutocompleteData(cmd, "", "Display build info")
 }
@@ -43,11 +45,7 @@ func BuildInfo(manifest model.Manifest, props map[string]any) (string, error) {
 
 	path := info.Main.Path
 
-	reg, err := regexp.Compile(`/v\d$`)
-	if err != nil {
-		return "", err
-	}
-	matches := reg.FindAllString(path, -1)
+	matches := versionRegexp.FindAllString(path, -1)
 	if len(matches) > 0 {
 		path = strings.TrimSuffix(path, matches[len(matches)-1])
 	}
@@ -59,5 +57,12 @@ func BuildInfo(manifest model.Manifest, props map[string]any) (string, error) {
 		propsText += fmt.Sprintf(", %s: %v", k, v)
 	}
 
-	return fmt.Sprintf("%s version: %s, %s, built %s with %s%s\n", manifest.Name, manifest.Version, commit, buildTime.Format(time.RFC1123), info.GoVersion, propsText), nil
+	return fmt.Sprintf("%s version: %s, %s, built %s with %s%s\n",
+			manifest.Name,
+			manifest.Version,
+			commit,
+			buildTime.Format(time.RFC1123),
+			info.GoVersion,
+			propsText),
+		nil
 }

--- a/experimental/command/info.go
+++ b/experimental/command/info.go
@@ -17,7 +17,7 @@ func BuildInfoAutocomplete(cmd string) *model.AutocompleteData {
 	return model.NewAutocompleteData(cmd, "", "Display build info")
 }
 
-func BuildInfo(manifest model.Manifest, props map[string]any) (string, error) {
+func BuildInfo(manifest model.Manifest) (string, error) {
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
 		return "", errors.New("failed to read build info")
@@ -52,17 +52,11 @@ func BuildInfo(manifest model.Manifest, props map[string]any) (string, error) {
 
 	commit := fmt.Sprintf("[%s](https://%s/commit/%s)", revisionShort, path, revision)
 
-	var propsText string
-	for k, v := range props {
-		propsText += fmt.Sprintf(", %s: %v", k, v)
-	}
-
-	return fmt.Sprintf("%s version: %s, %s, built %s with %s%s\n",
+	return fmt.Sprintf("%s version: %s, %s, built %s with %s\n",
 			manifest.Name,
 			manifest.Version,
 			commit,
 			buildTime.Format(time.RFC1123),
-			info.GoVersion,
-			propsText),
+			info.GoVersion),
 		nil
 }

--- a/experimental/command/info.go
+++ b/experimental/command/info.go
@@ -11,70 +11,52 @@ import (
 	"github.com/pkg/errors"
 )
 
-type BuildInfo struct {
-	Manifest   model.Manifest
-	CommitSHA  string
-	BuildTime  time.Time
-	ModulePath string
-	GoVersion  string
-}
-
-func (b *BuildInfo) String() string {
-	path := b.ModulePath
-
-	matches := versionRegexp.FindAllString(path, -1)
-	if len(matches) > 0 {
-		path = strings.TrimSuffix(path, matches[len(matches)-1])
-	}
-
-	CommitSHAShort := b.CommitSHA[0:7]
-
-	commit := fmt.Sprintf("[%s](https://%s/commit/%s)", CommitSHAShort, path, b.CommitSHA)
-
-	return fmt.Sprintf("%s version: %s, %s, built %s with %s\n",
-		b.Manifest.Name,
-		b.Manifest.Version,
-		commit,
-		b.BuildTime.Format(time.RFC1123),
-		b.GoVersion)
-}
-
 var versionRegexp = regexp.MustCompile(`/v\d$`)
 
 func BuildInfoAutocomplete(cmd string) *model.AutocompleteData {
 	return model.NewAutocompleteData(cmd, "", "Display build info")
 }
 
-func GetBuildInfo(manifest model.Manifest) (*BuildInfo, error) {
+func BuildInfo(manifest model.Manifest) (string, error) {
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
-		return nil, errors.New("failed to read build info")
+		return "", errors.New("failed to read build info")
 	}
 
 	var (
-		revision  string
-		buildTime time.Time
+		revision      string
+		revisionShort string
+		buildTime     time.Time
 	)
 	for _, s := range info.Settings {
 		switch s.Key {
 		case "vcs.revision":
 			revision = s.Value
-
+			revisionShort = revision[0:7]
 		case "vcs.time":
 			var err error
 			buildTime, err = time.Parse(time.RFC3339, s.Value)
 
 			if err != nil {
-				return nil, err
+				return "", err
 			}
 		}
 	}
 
-	return &BuildInfo{
-		Manifest:   manifest,
-		CommitSHA:  revision,
-		BuildTime:  buildTime,
-		ModulePath: info.Main.Path,
-		GoVersion:  info.GoVersion,
-	}, nil
+	path := info.Main.Path
+
+	matches := versionRegexp.FindAllString(path, -1)
+	if len(matches) > 0 {
+		path = strings.TrimSuffix(path, matches[len(matches)-1])
+	}
+
+	commit := fmt.Sprintf("[%s](https://%s/commit/%s)", revisionShort, path, revision)
+
+	return fmt.Sprintf("%s version: %s, %s, built %s with %s\n",
+			manifest.Name,
+			manifest.Version,
+			commit,
+			buildTime.Format(time.RFC1123),
+			info.GoVersion),
+		nil
 }

--- a/experimental/command/info.go
+++ b/experimental/command/info.go
@@ -11,52 +11,70 @@ import (
 	"github.com/pkg/errors"
 )
 
-var versionRegexp = regexp.MustCompile(`/v\d$`)
-
-func BuildInfoAutocomplete(cmd string) *model.AutocompleteData {
-	return model.NewAutocompleteData(cmd, "", "Display build info")
+type BuildInfo struct {
+	Manifest   model.Manifest
+	CommitSHA  string
+	BuildTime  time.Time
+	ModulePath string
+	GoVersion  string
 }
 
-func BuildInfo(manifest model.Manifest) (string, error) {
-	info, ok := debug.ReadBuildInfo()
-	if !ok {
-		return "", errors.New("failed to read build info")
-	}
-
-	var (
-		revision      string
-		revisionShort string
-		buildTime     time.Time
-	)
-	for _, s := range info.Settings {
-		switch s.Key {
-		case "vcs.revision":
-			revision = s.Value
-			revisionShort = revision[0:7]
-		case "vcs.time":
-			var err error
-			buildTime, err = time.Parse(time.RFC3339, s.Value)
-
-			if err != nil {
-				return "", err
-			}
-		}
-	}
-
-	path := info.Main.Path
+func (b *BuildInfo) String() string {
+	path := b.ModulePath
 
 	matches := versionRegexp.FindAllString(path, -1)
 	if len(matches) > 0 {
 		path = strings.TrimSuffix(path, matches[len(matches)-1])
 	}
 
-	commit := fmt.Sprintf("[%s](https://%s/commit/%s)", revisionShort, path, revision)
+	CommitSHAShort := b.CommitSHA[0:7]
+
+	commit := fmt.Sprintf("[%s](https://%s/commit/%s)", CommitSHAShort, path, b.CommitSHA)
 
 	return fmt.Sprintf("%s version: %s, %s, built %s with %s\n",
-			manifest.Name,
-			manifest.Version,
-			commit,
-			buildTime.Format(time.RFC1123),
-			info.GoVersion),
-		nil
+		b.Manifest.Name,
+		b.Manifest.Version,
+		commit,
+		b.BuildTime.Format(time.RFC1123),
+		b.GoVersion)
+}
+
+var versionRegexp = regexp.MustCompile(`/v\d$`)
+
+func BuildInfoAutocomplete(cmd string) *model.AutocompleteData {
+	return model.NewAutocompleteData(cmd, "", "Display build info")
+}
+
+func GetBuildInfo(manifest model.Manifest) (*BuildInfo, error) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return nil, errors.New("failed to read build info")
+	}
+
+	var (
+		revision  string
+		buildTime time.Time
+	)
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			revision = s.Value
+
+		case "vcs.time":
+			var err error
+			buildTime, err = time.Parse(time.RFC3339, s.Value)
+
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return &BuildInfo{
+		Manifest:   manifest,
+		CommitSHA:  revision,
+		BuildTime:  buildTime,
+		ModulePath: info.Main.Path,
+		GoVersion:  info.GoVersion,
+	}, nil
 }


### PR DESCRIPTION
#### Summary


Since go1.18 [`debug.BuildSetting`](https://pkg.go.dev/runtime/debug@go1.18beta2#BuildSetting) is provided as part of [`debug.BuildInfo`](https://pkg.go.dev/runtime/debug@go1.18beta2#BuildInfo). It contains build information like the build commit or build time. 
This PR adds a helper helper which allows them to easily create a `about` command for easier debugging, without any build flags.

![Screenshot from 2022-02-11 11-29-12](https://user-images.githubusercontent.com/16541325/191358429-ddf9a81e-ca66-49a7-b4f3-e97ffca27b65.png)

An example usage on the plugin side can be found [here](https://github.com/mattermost/mattermost-plugin-github/commit/0e7ae53899bfc84ae342288e87e59dff6b36cab9).

#### Ticket Link
None
