### PR TITLE
Don't panic if no driver is provided

### DIFF
--- a/store.go
+++ b/store.go
@@ -89,6 +89,10 @@ func (s *StoreService) initialize() error {
 		return nil
 	}
 
+	if s.driver == nil {
+		return errors.New("no db driver was provided")
+	}
+
 	config := s.api.GetUnsanitizedConfig()
 
 	// Set up master db


### PR DESCRIPTION
#### Summary
If ` pluginapi.NewClient` is called with no driver i.e. `pluginapi.NewClient(p.API, nil)` any call to the DB store will panic. This PR changes the code to be more defensive and return an error for that case.

#### Ticket Link
None