### PR TITLE
[MM-51037] Add plugin cluster event method

### DIFF
--- a/client.go
+++ b/client.go
@@ -11,8 +11,9 @@ type Client struct {
 	api plugin.API
 
 	Bot           BotService
-	Configuration ConfigurationService
 	Channel       ChannelService
+	Cluster       ClusterService
+	Configuration ConfigurationService
 	SlashCommand  SlashCommandService
 	OAuth         OAuthService
 	Emoji         EmojiService
@@ -41,6 +42,7 @@ func NewClient(api plugin.API, driver plugin.Driver) *Client {
 
 		Bot:           BotService{api: api},
 		Channel:       ChannelService{api: api},
+		Cluster:       ClusterService{api: api},
 		Configuration: ConfigurationService{api: api},
 		SlashCommand:  SlashCommandService{api: api},
 		OAuth:         OAuthService{api: api},

--- a/cluster.go
+++ b/cluster.go
@@ -1,0 +1,23 @@
+package pluginapi
+
+import (
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
+)
+
+// ClusterService exposes methods to interact with cluster nodes.
+type ClusterService struct {
+	api plugin.API
+}
+
+// ClusterService broadcasts a plugin event to all other running instances of
+// the calling plugin that are present in the cluster.
+//
+// This method is used to allow plugin communication in a High-Availability cluster.
+// The receiving side should implement the OnPluginClusterEvent hook
+// to receive events sent through this method.
+//
+// Minimum server version: 5.36
+func (c *ClusterService) PublishPluginEvent(ev model.PluginClusterEvent, opts model.PluginClusterEventSendOptions) error {
+	return c.api.PublishPluginClusterEvent(ev, opts)
+}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1,0 +1,49 @@
+package pluginapi_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin/plugintest"
+
+	pluginapi "github.com/mattermost/mattermost-plugin-api"
+)
+
+func TestPublishPluginClusterEvent(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+		client := pluginapi.NewClient(api, &plugintest.Driver{})
+
+		api.On("PublishPluginClusterEvent",
+			model.PluginClusterEvent{Id: "someID", Data: []byte("foo")},
+			model.PluginClusterEventSendOptions{SendType: model.PluginClusterEventSendTypeReliable},
+		).Return(nil)
+
+		err := client.Cluster.PublishPluginEvent(
+			model.PluginClusterEvent{Id: "someID", Data: []byte("foo")},
+			model.PluginClusterEventSendOptions{SendType: model.PluginClusterEventSendTypeReliable},
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+		client := pluginapi.NewClient(api, &plugintest.Driver{})
+
+		api.On("PublishPluginClusterEvent",
+			model.PluginClusterEvent{Id: "someID", Data: []byte("foo")},
+			model.PluginClusterEventSendOptions{SendType: model.PluginClusterEventSendTypeReliable},
+		).Return(errors.New("someError"))
+
+		err := client.Cluster.PublishPluginEvent(
+			model.PluginClusterEvent{Id: "someID", Data: []byte("foo")},
+			model.PluginClusterEventSendOptions{SendType: model.PluginClusterEventSendTypeReliable},
+		)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
#### Summary
This method was added in https://github.com/mattermost/mattermost-server/pull/17495, but was never added to the plugin-api.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51037