### PR TITLE
Mm 51400 enable disable tracking

### DIFF
--- a/experimental/telemetry/doc.go
+++ b/experimental/telemetry/doc.go
@@ -36,26 +36,36 @@
 //     p.API.LogWarn("telemetry client not started", "error", err.Error())
 //     }
 //     ...
-//     p.tracker = telemetry.NewTracker(p.telemetryClient, p.API.GetDiagnosticId(), p.API.GetServerVersion(), manifest.Id,
-//     manifest.Version, "pluginName", enableDiagnostics, logger)
-//     }
-//  3. Init and update the tracker on configuration change
-//     func (p *Plugin) OnConfigurationChange() error {
-//     ...
-//     if enableDiagnostics && p.tracker != nil {
-//     p.tracker.Enable()
-//     } else if !enableDiagnostics && p.tracker != nil {
-//     p.tracker.Disable()
-//     }
-//     }
-//  4. Close the client on plugin deactivate
-//     func (p *Plugin) OnDeactivate() error {
-//     if p.telemetryClient != nil {
-//     err := p.telemetryClient.Close()
-//     if err != nil {
-//     p.API.LogWarn("OnDeactivate: failed to close telemetryClient", "error", err.Error())
-//     }
-//     }
-//     return nil
-//     }
+//     p.tracker = telemetry.NewTracker(
+//     p.telemetryClient,
+//     p.API.GetDiagnosticId(),
+//     p.API.GetServerVersion(),
+//     Manifest.Id,
+//     Manifest.Version,
+//     "github",
+//     telemetry.NewTrackerConfig(p.API),
+//     logger.New(p.API)
+//
+// )
+//
+//	   p.tracker = telemetry.NewTracker(p.telemetryClient, p.API.GetDiagnosticId(), p.API.GetServerVersion(), manifest.Id,
+//	   manifest.Version, "pluginName", telemetry.TrackerConfig{EnabledTracking: enabledTracking, EnabledLogging: enabledDeveloper}, logger)
+//	   }
+//	3. Init and update the tracker on configuration change
+//	   func (p *Plugin) OnConfigurationChange() error {
+//	   ...
+//	   if p.tracker != nil {
+//		p.tracker.ReloadConfig(telemetry.NewTrackerConfig(p.API))
+//	   }
+//	   }
+//	4. Close the client on plugin deactivate
+//	   func (p *Plugin) OnDeactivate() error {
+//	   if p.telemetryClient != nil {
+//	   err := p.telemetryClient.Close()
+//	   if err != nil {
+//	   p.API.LogWarn("OnDeactivate: failed to close telemetryClient", "error", err.Error())
+//	   }
+//	   }
+//	   return nil
+//	   }
 package telemetry

--- a/experimental/telemetry/doc.go
+++ b/experimental/telemetry/doc.go
@@ -34,23 +34,23 @@
 //
 // 2. Start the telemetry client and tracker on plugin activate
 //
-//		func (p *Plugin) OnActivate() error {
-//		    p.telemetryClient, err = telemetry.NewRudderClient()
-//		    if err != nil {
-//		        p.API.LogWarn("telemetry client not started", "error", err.Error())
-//		    }
-//	        ...
-//	        p.tracker = telemetry.NewTracker(
-//	           p.telemetryClient,
-//	           p.API.GetDiagnosticId(),
-//	           p.API.GetServerVersion(),
-//	           Manifest.Id,
-//	           Manifest.Version,
-//	           "plugin_short_namame",
-//	           telemetry.NewTrackerConfig(p.API.GetConfig()),
-//	           logger.New(p.API)
-//	        )
+//	func (p *Plugin) OnActivate() error {
+//		p.telemetryClient, err = telemetry.NewRudderClient()
+//		if err != nil {
+//			p.API.LogWarn("telemetry client not started", "error", err.Error())
 //		}
+//		...
+//		p.tracker = telemetry.NewTracker(
+//			p.telemetryClient,
+//			p.API.GetDiagnosticId(),
+//			p.API.GetServerVersion(),
+//			Manifest.Id,
+//			Manifest.Version,
+//			"plugin_short_namame",
+//			telemetry.NewTrackerConfig(p.API.GetConfig()),
+//			logger.New(p.API)
+//		)
+//	}
 //
 // 3. Trigger tracker changes when configuration changes
 //

--- a/experimental/telemetry/doc.go
+++ b/experimental/telemetry/doc.go
@@ -35,13 +35,18 @@
 //     if err != nil {
 //     p.API.LogWarn("telemetry client not started", "error", err.Error())
 //     }
+//     ...
+//     p.tracker = telemetry.NewTracker(p.telemetryClient, p.API.GetDiagnosticId(), p.API.GetServerVersion(), manifest.Id,
+//     manifest.Version, "pluginName", enableDiagnostics, logger)
 //     }
 //  3. Init and update the tracker on configuration change
 //     func (p *Plugin) OnConfigurationChange() error {
 //     ...
-//     p.tracker = telemetry.NewTracker(p.telemetryClient, p.API.GetDiagnosticId(), p.API.GetServerVersion(), manifest.Id,
-//     manifest.Version, "pluginName", enableDiagnostics, logger)
-//     return nil
+//     if enableDiagnostics && p.tracker != nil {
+//     p.tracker.Enable()
+//     } else if !enableDiagnostics && p.tracker != nil {
+//     p.tracker.Disable()
+//     }
 //     }
 //  4. Close the client on plugin deactivate
 //     func (p *Plugin) OnDeactivate() error {

--- a/experimental/telemetry/doc.go
+++ b/experimental/telemetry/doc.go
@@ -26,10 +26,10 @@
 // 1. Add the new fields to the plugin
 //
 //	type Plugin struct {
-//	    plugin.MattermostPlugin
-//	    ...
-//	    telemetryClient telemetry.Client
-//	    tracker         telemetry.Tracker
+//		plugin.MattermostPlugin
+//		...
+//		telemetryClient telemetry.Client
+//		tracker         telemetry.Tracker
 //	}
 //
 // 2. Start the telemetry client and tracker on plugin activate
@@ -55,22 +55,22 @@
 // 3. Trigger tracker changes when configuration changes
 //
 //	func (p *Plugin) OnConfigurationChange() error {
-//	   ...
-//	   if p.tracker != nil {
-//	     p.tracker.ReloadConfig(telemetry.NewTrackerConfig(p.API.GetConfig()))
-//	   }
-//	   return nil
+//		...
+//		if p.tracker != nil {
+//			p.tracker.ReloadConfig(telemetry.NewTrackerConfig(p.API.GetConfig()))
+//		}
+//		return nil
 //	}
 //
 // 4. Close the client on plugin deactivate
 //
 //	func (p *Plugin) OnDeactivate() error {
-//	   if p.telemetryClient != nil {
-//	      err := p.telemetryClient.Close()
-//	      if err != nil {
-//	         p.API.LogWarn("OnDeactivate: failed to close telemetryClient", "error", err.Error())
-//	      }
-//	   }
-//	   return nil
+//		if p.telemetryClient != nil {
+//			err := p.telemetryClient.Close()
+//			if err != nil {
+//				p.API.LogWarn("OnDeactivate: failed to close telemetryClient", "error", err.Error())
+//			}
+//		}
+//		return nil
 //	}
 package telemetry

--- a/experimental/telemetry/tracker.go
+++ b/experimental/telemetry/tracker.go
@@ -17,14 +17,16 @@ type TrackerConfig struct {
 func NewTrackerConfig(api plugin.API) TrackerConfig {
 	var enabledTracking, enabledLogging bool
 	if config := api.GetConfig(); config != nil {
-		if configValue := config.LogSettings.EnableDiagnostics; configValue != nil {
-			enabledTracking = *configValue
+		if enableDiagnostics := config.LogSettings.EnableDiagnostics; enableDiagnostics != nil {
+			enabledTracking = *enableDiagnostics
 		}
-		if configValue := config.ServiceSettings.EnableDeveloper; configValue != nil {
-			enabledLogging = *configValue
+        
+		if enableDeveloper := config.ServiceSettings.EnableDeveloper; enableDeveloper != nil {
+			enabledLogging = *enableDeveloper
 		}
-	}
-	return TrackerConfig{
+    }
+
+    return TrackerConfig{
 		EnabledTracking: enabledTracking,
 		EnabledLogging:  enabledLogging,
 	}

--- a/experimental/telemetry/tracker.go
+++ b/experimental/telemetry/tracker.go
@@ -1,6 +1,7 @@
 package telemetry
 
 import (
+	"github.com/mattermost/mattermost-plugin-api/experimental/bot/logger"
 	"github.com/pkg/errors"
 )
 
@@ -10,6 +11,10 @@ type Tracker interface {
 	TrackEvent(event string, properties map[string]interface{}) error
 	// TrackUserEvent registers an event through the configured telemetry client associated to a user
 	TrackUserEvent(event string, userID string, properties map[string]interface{}) error
+	// Enable allow the events to be sent to the telemetry client
+	Enable()
+	// Disable stops the events flow, discarding any event left on the queue
+	Disable()
 }
 
 // Client defines a telemetry client
@@ -35,6 +40,7 @@ type tracker struct {
 	pluginVersion      string
 	telemetryShortName string
 	enabled            bool
+	logger             logger.Logger
 }
 
 // NewTracker creates a default Tracker
@@ -46,7 +52,7 @@ type tracker struct {
 // - telemetryShortName: Short name for the plugin to use in telemetry. Used to avoid dot separated names like `com.company.pluginName`.
 // If a empty string is provided, it will use the pluginID.
 // - enableDiagnostics: Whether the system has enabled sending telemetry data. If false, the tracker will not track any event.
-// - l Logger: A logger to log any error related with the telemetry tracking.
+// - l Logger: A logger to debug event tracking and some important changes (it wont log if nil is passed as logger).
 func NewTracker(
 	c Client,
 	diagnosticID,
@@ -55,6 +61,7 @@ func NewTracker(
 	pluginVersion,
 	telemetryShortName string,
 	enableDiagnostics bool,
+	l logger.Logger,
 ) Tracker {
 	if telemetryShortName == "" {
 		telemetryShortName = pluginID
@@ -67,19 +74,38 @@ func NewTracker(
 		pluginID:           pluginID,
 		pluginVersion:      pluginVersion,
 		enabled:            enableDiagnostics,
+		logger:             l,
 	}
 }
 
+func (t *tracker) Enable() {
+	t.debugf("Enabling plugin telemetry")
+	t.enabled = true
+}
+
+func (t *tracker) Disable() {
+	t.debugf("Disabling plugin telemetry")
+	t.enabled = false
+}
+
+func (t *tracker) debugf(message string, args ...interface{}) {
+	if t.logger == nil {
+		return
+	}
+	t.logger.Debugf(message, args...)
+
+}
+
 func (t *tracker) TrackEvent(event string, properties map[string]interface{}) error {
+	event = t.telemetryShortName + "_" + event
 	if !t.enabled || t.client == nil {
+		t.debugf("Plugin telemetry event `%s` triggered, but not sent due to configuration", event)
 		return nil
 	}
 
 	if properties == nil {
 		properties = map[string]interface{}{}
 	}
-
-	event = t.telemetryShortName + "_" + event
 	properties["PluginID"] = t.pluginID
 	properties["PluginVersion"] = t.pluginVersion
 	properties["ServerVersion"] = t.serverVersion
@@ -93,6 +119,7 @@ func (t *tracker) TrackEvent(event string, properties map[string]interface{}) er
 	if err != nil {
 		return errors.Wrap(err, "cannot enqueue the track")
 	}
+	t.debugf("Plugin telemetry event `%s` triggered", event)
 
 	return nil
 }

--- a/experimental/telemetry/tracker.go
+++ b/experimental/telemetry/tracker.go
@@ -20,13 +20,13 @@ func NewTrackerConfig(api plugin.API) TrackerConfig {
 		if enableDiagnostics := config.LogSettings.EnableDiagnostics; enableDiagnostics != nil {
 			enabledTracking = *enableDiagnostics
 		}
-        
+
 		if enableDeveloper := config.ServiceSettings.EnableDeveloper; enableDeveloper != nil {
 			enabledLogging = *enableDeveloper
 		}
-    }
+	}
 
-    return TrackerConfig{
+	return TrackerConfig{
 		EnabledTracking: enabledTracking,
 		EnabledLogging:  enabledLogging,
 	}
@@ -112,8 +112,9 @@ func (t *tracker) ReloadConfig(config TrackerConfig) {
 		} else {
 			t.debugf("Disabling plugin telemetry")
 		}
-		t.enabledTracking = config.EnabledTracking
 	}
+
+	t.enabledTracking = config.EnabledTracking
 	t.enabledLogging = config.EnabledLogging
 }
 

--- a/experimental/telemetry/tracker.go
+++ b/experimental/telemetry/tracker.go
@@ -1,8 +1,9 @@
 package telemetry
 
 import (
-	"github.com/mattermost/mattermost-plugin-api/experimental/bot/logger"
 	"github.com/pkg/errors"
+
+	"github.com/mattermost/mattermost-plugin-api/experimental/bot/logger"
 )
 
 // Tracker defines a telemetry tracker
@@ -93,7 +94,6 @@ func (t *tracker) debugf(message string, args ...interface{}) {
 		return
 	}
 	t.logger.Debugf(message, args...)
-
 }
 
 func (t *tracker) TrackEvent(event string, properties map[string]interface{}) error {

--- a/experimental/telemetry/tracker.go
+++ b/experimental/telemetry/tracker.go
@@ -99,7 +99,7 @@ func (t *tracker) debugf(message string, args ...interface{}) {
 func (t *tracker) TrackEvent(event string, properties map[string]interface{}) error {
 	event = t.telemetryShortName + "_" + event
 	if !t.enabled || t.client == nil {
-		t.debugf("Plugin telemetry event `%s` triggered, but not sent due to configuration", event)
+		t.debugf("Plugin telemetry event `%s` tracked, but not sent due to configuration", event)
 		return nil
 	}
 

--- a/experimental/telemetry/tracker.go
+++ b/experimental/telemetry/tracker.go
@@ -119,7 +119,7 @@ func (t *tracker) TrackEvent(event string, properties map[string]interface{}) er
 	if err != nil {
 		return errors.Wrap(err, "cannot enqueue the track")
 	}
-	t.debugf("Plugin telemetry event `%s` triggered", event)
+	t.debugf("Tracked plugin telemetry event `%s`", event)
 
 	return nil
 }

--- a/experimental/telemetry/tracker.go
+++ b/experimental/telemetry/tracker.go
@@ -78,7 +78,7 @@ type tracker struct {
 // - telemetryShortName: Short name for the plugin to use in telemetry. Used to avoid dot separated names like `com.company.pluginName`.
 // If a empty string is provided, it will use the pluginID.
 // - config: Whether the system has enabled sending telemetry data. If false, the tracker will not track any event.
-// - l Logger: A logger to debug event tracking and some important changes (it wont log if nil is passed as logger).
+// - l Logger: A logger to debug event tracking and some important changes (it won't log if nil is passed as logger).
 func NewTracker(
 	c Client,
 	diagnosticID,


### PR DESCRIPTION
### Enable/Disable
Add the ability to enable/disable telemetry trackers at pluginAPI.

The main goal is to get tracker/client creation together and avoid hook order race conditions that end up with trackers with null clients or flowmanagers with outdated trackers.

Related gihub plugin pr https://github.com/mattermost/mattermost-plugin-github/pull/659

Add `Enable` and `Disable` to the Tracker interface and implementations to the tracker struct.

All telemetry client & tracker initialization is done at onActivate, and OnConfigurationChange will only take care of config reload.

OnActivate
```go
	// Telemetry client
	p.telemetryClient, err = telemetry.NewRudderClient()
	if err != nil {
		p.API.LogWarn("Telemetry client not started", "error", err.Error())
		return
	}

	// Get config values
	p.tracker = telemetry.NewTracker(
		p.telemetryClient,
		p.API.GetDiagnosticId(),
		p.API.GetServerVersion(),
		Manifest.Id,
		Manifest.Version,
		"shortname",
		telemetry.NewTrackerConfig(p.API),
		logger.New(p.API),
	)
```

OnConfigurationChange
```go
	if p.tracker != nil {
		p.tracker.ReloadConfig(telemetry.NewTrackerConfig(p.API))
	}
```

OnDeactivate
```go
	if err := p.telemetryClient.Close(); err != nil {
		p.API.LogWarn("Telemetry client failed to close", "error", err.Error())
	}
```



### Debug at development stage
Opportunistic change to debug telemetry (without rudder access).

The current documentation has a logger as a parameter of NewTracker (at doc.go and func docstring) but was removed at some point. However, I see much value in passing a logger to debug telemetry events. 

It's a bit defensive, and won't debug anything if nil is passed, and actually, from the NewTrackerConfig I choose to pass a logger just when ServiceSettings.EnableDeveloper is true. 


<img width="2501" alt="Screenshot 2023-03-20 at 17 49 49" src="https://user-images.githubusercontent.com/4096774/226411359-e4884e14-0109-4997-b18a-014ce4d53041.png">


#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-51400
