### PR TITLE
Fix rudder data plane env variable

### DIFF
--- a/experimental/telemetry/doc.go
+++ b/experimental/telemetry/doc.go
@@ -17,9 +17,9 @@
 // MM_RUDDER_WRITE_KEY environment variable must be set also during CI
 // to the production write key ("1dP7Oi78p0PK1brYLsfslgnbD1I").
 // If you want to use your own data plane URL, add also this line and
-// make sure the MM_RUDDER_DATA_PLANE_URL environment variable is set.
+// make sure the MM_RUDDER_DATAPLANE_URL environment variable is set.
 //
-//	LDFLAGS += -X "github.com/mattermost/mattermost-plugin-api/experimental/telemetry.rudderDataPlaneURL=$(MM_RUDDER_DATA_PLANE_URL)"
+//	LDFLAGS += -X "github.com/mattermost/mattermost-plugin-api/experimental/telemetry.rudderDataPlaneURL=$(MM_RUDDER_DATAPLANE_URL)"
 //
 // In order to use telemetry you should:
 //


### PR DESCRIPTION
#### Summary
As far as I can tell, no plugin makes use of this env variable currently, so there is no need to rename it somewhere else.

#### Ticket Link
https://community.mattermost.com/private-core/pl/9wxkzzicj3ns5j3q99xtrpuduy