### PR TITLE
Archive repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# This repository has been moved into a monorepo located in https://github.com/mattermost/mattermost. Please take a look a the [godoc](https://pkg.go.dev/github.com/mattermost/mattermost/server/public/pluginapi) for more information.
+
 # mattermost-plugin-api
 
 [![GoDoc](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)](https://pkg.go.dev/github.com/mattermost/mattermost-plugin-api)


### PR DESCRIPTION
#### Summary
With https://github.com/mattermost/mattermost/pull/24235 merged, this repo is no longer needed.

#### Ticket Link
None
